### PR TITLE
update to optic14n v1.0.0 (yes, we cope with?non&html&querystrings)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'activerecord'
 gem 'mysql2'
 gem 'nokogiri'
 gem 'rack'
-gem 'optic14n'
+gem 'optic14n', '>= 1.0.0'
 
 group :production do
   gem 'unicorn', '4.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     mysql2 (0.3.11)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
-    optic14n (0.0.4)
+    optic14n (1.0.0)
       addressable (~> 2.3)
     rack (1.5.2)
     rack-test (0.6.2)
@@ -62,7 +62,7 @@ DEPENDENCIES
   database_cleaner
   mysql2
   nokogiri
-  optic14n
+  optic14n (>= 1.0.0)
   rack
   rack-test
   rake

--- a/lib/bouncer/app.rb
+++ b/lib/bouncer/app.rb
@@ -33,6 +33,7 @@ class Bouncer::App
   end
 
   def serve_status(host, mappings, request)
+    # Reminder: the hash is always calculated on the canonicalize!d request
     mapping = mappings.find_by path_hash: Digest::SHA1.hexdigest(request.fullpath)
     context = RenderingContext.new(context_attributes_from_request(host, request, mapping))
 

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -226,5 +226,17 @@ describe 'HTTP request handling' do
 
       last_response.status.should == 410
     end
+
+    specify 'Non HTML-encoded querystrings do not get thrown away' do
+      path = '/an-archived-page?with&a&weird&querystring'
+      site.mappings.create \
+        path: path,
+        path_hash:    Digest::SHA1.hexdigest('/an-archived-page?a&querystring&weird&with'),
+        http_status:  '410'
+
+      get "http://www.minitrue.gov.uk#{path}"
+
+      last_response.status.should == 410
+    end
   end
 end


### PR DESCRIPTION
Start coping with non-HTML-encoded querystrings. Instead of throwing them away.
