### PR TITLE
Non-whitelisted domains 501

### DIFF
--- a/lib/bouncer/outcome/base.rb
+++ b/lib/bouncer/outcome/base.rb
@@ -9,7 +9,7 @@ module Bouncer
       if legal_redirect?(url)
         [301, { 'Location' => url }, []]
       else
-        [500, { 'Content-Type' => 'text/plain' }, "Refusing to redirect to non *.gov.uk domain: #{url}"]
+        [501, { 'Content-Type' => 'text/plain' }, "Refusing to redirect to non-whitelisted domain: #{url}"]
       end
     end
 

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -141,7 +141,8 @@ describe 'HTTP request handling' do
       get 'https://www.minitrue.gov.uk/a-redirected-page'
     end
 
-    it_behaves_like 'a server error'
+    its(:status) { should == 501 }
+    its(:location) { should == nil }
   end
 
   describe 'visiting a URL which has been archived' do
@@ -323,7 +324,10 @@ describe 'HTTP request handling' do
       get 'http://www.minitrue.gov.uk'
     end
 
-    it_behaves_like 'a server error'
+    its(:status) { should == 501 }
+    its(:body) { should match %r{non\-whitelisted}}
+    its(:body) { should match %r{spam.net} }
+    its(:location) { should == nil }
   end
 
   context 'when the host is not recognised' do


### PR DESCRIPTION
Non-whitelisted redirect requests are the only circumstance in which bouncer produces an error indistinguishable in logs alone from an unhandled error.  This moves that class of response onto `501 Not Implemented` 
