### PR TITLE
Fallback to homepage if no furl

### DIFF
--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -265,6 +265,15 @@ describe 'HTTP request handling' do
     its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/410">This item has been archived</a>' }
   end
 
+  describe 'visiting a /410 URL with no furl' do
+    before do
+      organisation.update_attribute(:furl, nil)
+      get 'http://www.minitrue.gov.uk/410'
+    end
+
+    its(:body) { should include 'Visit the new Ministry of Truth site at <a href="http://www.gov.uk/government/organisations/ministry-of-truth">http://www.gov.uk/government/organisations/ministry-of-truth</a>' }
+  end
+
   describe 'visiting a /sitemap.xml URL' do
     before do
       site.mappings.create \

--- a/templates/410.erb
+++ b/templates/410.erb
@@ -31,7 +31,7 @@
             <p class="either-or">You can either</p>
             <p class="call-to-action"><a href="<%= archive_link %>">View the item you were looking for</a> in the UK Government Web Archive</p>
             <p class="either-or">or</p>
-            <p class="call-to-action">Visit the new <%= title %> site at <a href="<%= homepage %>"><%= furl %></a></p>
+            <p class="call-to-action">Visit the new <%= title %> site at <a href="<%= homepage %>"><%= furl || homepage %></a></p>
             <% if suggested_link %>
               <p class="either-or">or</p>
               <p class="call-to-action">Visit <%= suggested_link %> for more information on this topic.</p>


### PR DESCRIPTION
Previously we would have rendered a link with no clickable area because not all
organisations (especially ALBs) have furls.
