### PR TITLE
Only include redirects in sitemaps

### DIFF
--- a/lib/bouncer/outcome/sitemap.rb
+++ b/lib/bouncer/outcome/sitemap.rb
@@ -8,7 +8,7 @@ module Bouncer
       def build_sitemap
         Nokogiri::XML::Builder.new do |xml|
           xml.urlset xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9' do
-            context.mappings.each do |mapping|
+            context.mappings.where("http_status like '3%'").each do |mapping|
               url = URI.parse(mapping.path).tap do |uri|
                 uri.scheme = 'http'
                 uri.host   = context.request.host

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -287,10 +287,14 @@ describe 'HTTP request handling' do
         http_status:  '301',
         new_url:      'http://www.gov.uk/government/organisations/ministry-of-truth/a-redirected-page'
       site.mappings.create \
+        path:         '/a-deleted-page',
+        path_hash:    Digest::SHA1.hexdigest('/a-deleted-page'),
+        http_status:  '404'
+      site.mappings.create \
         path:         '/an-archived-page',
         path_hash:    Digest::SHA1.hexdigest('/an-archived-page'),
         http_status:  '410'
-  
+
       get 'http://www.minitrue.gov.uk/sitemap.xml'
     end
 
@@ -300,7 +304,8 @@ describe 'HTTP request handling' do
     its(:body) { should be_valid_sitemap }
     its(:body) { should have_sitemap_entry_for 'http://www.minitrue.gov.uk/a-redirected-page' }
     its(:body) { should have_sitemap_entry_for 'http://www.minitrue.gov.uk/a-redirected-page?p=np' }
-    its(:body) { should have_sitemap_entry_for 'http://www.minitrue.gov.uk/an-archived-page' }
+    its(:body) { should_not have_sitemap_entry_for 'http://www.minitrue.gov.uk/a-deleted-page' }
+    its(:body) { should_not have_sitemap_entry_for 'http://www.minitrue.gov.uk/an-archived-page' }
     its(:content_type) { should == 'application/xml' }
   end
 


### PR DESCRIPTION
It's not helpful to have entries which point at 404s or 410s. Including redirescts meant that rendering took longer and we were more likely to reach the 50k URL limit for sitemaps.

This more or less copies the behaviour of the Redirector: https://github.com/alphagov/redirector/blob/master/tools/generate_sitemap.pl#L33

This should also fix the only failing smokey test for Bouncer.
