### PR TITLE
Pin gem versions as per styleguide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,23 @@
 source 'https://rubygems.org/'
 source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
-gem 'activerecord'
-gem 'mysql2'
-gem 'nokogiri'
-gem 'rack'
-gem 'optic14n', '>= 1.0.0'
+gem 'activerecord', '4.0.0' # This is a mismatch for Transition, which has 3.2.13
+gem 'mysql2', '0.3.11'
+gem 'nokogiri', '1.6.0'
+gem 'rack', '1.5.2'
+gem 'optic14n', '1.0.0'
 
 group :production do
   gem 'unicorn', '4.6.3'
 end
 
 group :development do
-  gem "mr-sparkle", "0.2.0"
+  gem "mr-sparkle", '0.2.0'
 end
 
 group :test do
-  gem 'database_cleaner'
-  gem 'rack-test'
-  gem 'rake'
-  gem 'rspec'
+  gem 'database_cleaner', '1.0.1'
+  gem 'rack-test', '0.6.2'
+  gem 'rake', '10.1.0'
+  gem 'rspec', '2.13.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,14 +73,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
-  database_cleaner
+  activerecord (= 4.0.0)
+  database_cleaner (= 1.0.1)
   mr-sparkle (= 0.2.0)
-  mysql2
-  nokogiri
-  optic14n (>= 1.0.0)
-  rack
-  rack-test
-  rake
-  rspec
+  mysql2 (= 0.3.11)
+  nokogiri (= 1.6.0)
+  optic14n (= 1.0.0)
+  rack (= 1.5.2)
+  rack-test (= 0.6.2)
+  rake (= 10.1.0)
+  rspec (= 2.13.0)
   unicorn (= 4.6.3)


### PR DESCRIPTION
Pinning gem versions speeds up dependency resolution and also documents intent.

In this case, it has highlighted that we are using a very different
ActiveRecord: 4.0.0. vs 3.2.13 in the Transition app. I'll investigate and resolve that separately.
