### PR TITLE
Support global site mappings

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -71,6 +71,8 @@ CREATE TABLE `sites` (
   `homepage` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
+  `global_http_status` varchar(3) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `global_new_url` text COLLATE utf8_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sites_on_site` (`site`),
   KEY `index_sites_on_organisation_id` (`organisation_id`)

--- a/lib/bouncer/outcome/status.rb
+++ b/lib/bouncer/outcome/status.rb
@@ -2,17 +2,26 @@ module Bouncer
   module Outcome
     class Status < Base
       def serve
-        case context.mapping.try(:http_status)
-        when '301'
-          guarded_redirect(context.mapping.new_url)
-        when '410'
-          [410, { 'Content-Type' => 'text/html' }, [renderer.render(context, 410)]]
+        if context.site.global_http_status
+          case context.site.global_http_status
+          when '301'
+            guarded_redirect(context.site.global_new_url)
+          when '410'
+            [410, { 'Content-Type' => 'text/html' }, [renderer.render(context, 410)]]
+          end
         else
-          if request.path == '/410'
+          case context.mapping.try(:http_status)
+          when '301'
+            guarded_redirect(context.mapping.new_url)
+          when '410'
             [410, { 'Content-Type' => 'text/html' }, [renderer.render(context, 410)]]
           else
-            Bouncer::Rules.try(context, renderer) or
-              [404, { 'Content-Type' => 'text/html' }, [renderer.render(context, 404)]]
+            if request.path == '/410'
+              [410, { 'Content-Type' => 'text/html' }, [renderer.render(context, 410)]]
+            else
+              Bouncer::Rules.try(context, renderer) or
+                [404, { 'Content-Type' => 'text/html' }, [renderer.render(context, 404)]]
+            end
           end
         end
       end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -267,6 +267,26 @@ describe 'HTTP request handling' do
     its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20130724103251/http://www.miniluv.gov.uk">UK Government Web Archive</a>' }
   end
 
+  describe 'visiting a URL on a site with a global redirect' do
+    before do
+      site.update_attribute(:global_http_status, '301')
+      site.update_attribute(:global_new_url, 'http://www.gov.uk/global-new')
+      get 'http://www.minitrue.gov.uk/any-page'
+    end
+
+    it_behaves_like 'a redirect'
+    its(:location) { should == 'http://www.gov.uk/global-new' }
+  end
+
+  describe 'visiting a URL on a site with a global 410' do
+    before do
+      site.update_attribute(:global_http_status, '410')
+      get 'http://www.minitrue.gov.uk/any-page'
+    end
+
+    it_behaves_like 'a 410'
+  end
+
   describe 'visiting a /404 URL' do
     before do
       get 'http://www.minitrue.gov.uk/404'

--- a/spec/units/bouncer/app_spec.rb
+++ b/spec/units/bouncer/app_spec.rb
@@ -44,6 +44,7 @@ describe Bouncer::App do
       host.stub site: site
       site.stub mappings: mappings
       site.stub query_params: nil
+      site.stub global_http_status: nil
       mappings.stub find_by: mapping
     end
 


### PR DESCRIPTION
Redirector supports the idea of providing a mapping for an entire site, and we need to be compatible with redirector's features/data model.

Related: https://github.com/alphagov/transition/pull/79
