### PR TITLE
Support aka.foo.com == www.foo.com aka hostnames

### DIFF
--- a/lib/bouncer/canonicalized_request.rb
+++ b/lib/bouncer/canonicalized_request.rb
@@ -21,7 +21,19 @@ module Bouncer
     end
 
     def host
-      @request.host.sub(/^aka-/, '')
+      # This behaviour is based on a reading of
+      # https://github.com/alphagov/redirector/blob/b7713cf5bb175a4a31b47e4aa191399c294da11b/templates/nginx.erb#L16
+      #
+      # When deciding on aka hostnames to use, we use the following logic:
+      #
+      #   If it does not start with www., we add aka- to the hostname:
+      #     foo.com => aka-foo.com
+      #
+      #   If it starts with www. we replace www with aka.:
+      #     www.bar.com => aka.bar.com
+      #
+      # Therefore, to canonicalise it, we need to reverse that transformation:
+      @request.host.sub(/^aka-/, '').sub(/^aka\./, 'www.')
     end
 
   private

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -109,12 +109,24 @@ describe 'HTTP request handling' do
         path_hash:    Digest::SHA1.hexdigest('/a-redirected-page'),
         http_status:  '301',
         new_url:      'http://www.gov.uk/government/organisations/ministry-of-truth/a-redirected-page'
-
-      get 'http://aka-www.minitrue.gov.uk/a-redirected-page///'
     end
 
-    it_behaves_like 'a redirect'
-    its(:location) { should == 'http://www.gov.uk/government/organisations/ministry-of-truth/a-redirected-page' }
+    context "aka-hostname style" do
+      before do
+        site.hosts.first.update_attribute(:host, "minitrue.gov.uk")
+        get 'http://aka-minitrue.gov.uk/a-redirected-page'
+      end
+      it_behaves_like 'a redirect'
+      its(:location) { should == 'http://www.gov.uk/government/organisations/ministry-of-truth/a-redirected-page' }
+    end
+
+    context "aka.hostname style" do
+      before do
+        get 'http://aka.minitrue.gov.uk/a-redirected-page'
+      end
+      it_behaves_like 'a redirect'
+      its(:location) { should == 'http://www.gov.uk/government/organisations/ministry-of-truth/a-redirected-page' }
+    end
   end
 
   describe 'visiting a URL with significant query parameters' do


### PR DESCRIPTION
We use a different aka hostname based on whether or not the original hostname began with 'www.'. My basis for this is that we have tests in redirector which try eg http://aka.homeoffice.gov.uk which pass against redirector but fail against bouncer.

Hopefully @annashipman or @norm can tell whether or not I've understood the (intention of the) redirector's behaviour correctly? That's the primary reason for the Pull Request. We can have a chat so I can explain Bouncer if that would help.
