### PR TITLE
Bump ActiveRecord to 4.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org/'
 source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
-gem 'activerecord', '4.0.0' # This is a mismatch for Transition, which has 3.2.13
+gem 'activerecord', '4.0.2' # This is a mismatch for Transition, which has 3.2.x
 gem 'aws-ses', '0.5.0'
 gem 'mysql2', '0.3.11'
 gem 'nokogiri', '1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,24 +2,24 @@ GEM
   remote: https://rubygems.org/
   remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
-    activemodel (4.0.0)
-      activesupport (= 4.0.0)
+    activemodel (4.0.2)
+      activesupport (= 4.0.2)
       builder (~> 3.1.0)
-    activerecord (4.0.0)
-      activemodel (= 4.0.0)
+    activerecord (4.0.2)
+      activemodel (= 4.0.2)
       activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.0)
+      activesupport (= 4.0.2)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.0)
+    activesupport (4.0.2)
       i18n (~> 0.6, >= 0.6.4)
       minitest (~> 4.2)
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     addressable (2.3.5)
-    arel (4.0.0)
-    atomic (1.1.10)
+    arel (4.0.1)
+    atomic (1.1.14)
     aws-ses (0.5.0)
       builder
       mail (> 2.2.5)
@@ -30,7 +30,7 @@ GEM
     diff-lcs (1.2.4)
     erubis (2.7.0)
     ffi (1.9.0)
-    i18n (0.6.4)
+    i18n (0.6.9)
     kgio (2.8.0)
     listen (1.3.0)
       rb-fsevent (>= 0.9.3)
@@ -47,7 +47,7 @@ GEM
       rb-fsevent (>= 0.9)
       rb-inotify (>= 0.8)
       unicorn (>= 4.5)
-    multi_json (1.7.7)
+    multi_json (1.8.2)
     mysql2 (0.3.11)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
@@ -72,12 +72,12 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    thread_safe (0.1.0)
+    thread_safe (0.1.3)
       atomic
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.37)
+    tzinfo (0.3.38)
     unicorn (4.6.3)
       kgio (~> 2.6)
       rack
@@ -88,7 +88,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (= 4.0.0)
+  activerecord (= 4.0.2)
   aws-ses (= 0.5.0)
   database_cleaner (= 1.0.1)
   erubis (= 2.7.0)


### PR DESCRIPTION
- This addresses a theoretical-for-Bouncer security vulnerability
  https://groups.google.com/forum/#!topic/rubyonrails-security/pLrh6DUw998
