### PR TITLE
Add forthcoming GDS Blog to whitelist

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -222,3 +222,4 @@ www.nationaltnas.gov.uk
 vivbennett.dh.gov.uk
 admin.events.businesslink.gov.uk
 admin.business-events.org.uk
+gds.blog.gov.uk


### PR DESCRIPTION
This is the intended domain name of the GDS blog. Before we can serve redirects to it, we need it in the whitelist.
