### PR TITLE
Add 3 domains to whitelist for DFT

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -3,6 +3,8 @@ army.mod.uk
 foodanddrink.nsacademy.co.uk
 mps-academy.co.uk
 nsa-ccskills.co.uk
+public.govdelivery.com
+service.govdelivery.com
 services.parliament.uk
 skillsmart.nsaforretail.com
 wsr.pearsonvue.com
@@ -22,6 +24,7 @@ www.electoralcommission.org.uk
 www.esd.org.uk
 www.getsafeonline.org
 www.greendealorb.co.uk
+www.highwaysefficiency.org.uk
 www.iaea.org
 www.itskillsacademy.ac.uk
 www.maa.mod.uk


### PR DESCRIPTION
www.dft.gov.uk is currently supplier-redirected and already redirects
a few pages to these domains. They were added to Redirector in
https://github.com/alphagov/redirector/pull/484 - the other domains
added there are *.gov.uk subdomains so don't need to be included in
Bouncer's whitelist.
