### PR TITLE
Add missing entry from whitelist

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -27,6 +27,7 @@ www.greendealorb.co.uk
 www.highwaysefficiency.org.uk
 www.iaea.org
 www.itskillsacademy.ac.uk
+www.lituktestbooking.co.uk
 www.maa.mod.uk
 www.mod.uk
 www.moneyadviceservice.org.uk


### PR DESCRIPTION
This is needed for some redirects on lifeintheuktest.ukba.homeoffice.gov.uk
