### PR TITLE
Add dasa.mod.uk new tool subdomain to whitelist

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -1,5 +1,6 @@
 # whitelist of domains which may be used in a New Url, in addition to anything on *.gov.uk
 army.mod.uk
+byot.dasa.mod.uk
 foodanddrink.nsacademy.co.uk
 mps-academy.co.uk
 nsa-ccskills.co.uk


### PR DESCRIPTION
This is required to avoid an aka-partial transition of the domain for the sake of one tool.
