### PR TITLE
Add more Environment Agency flood redirect rules

### DIFF
--- a/lib/bouncer/preemptive_rules.rb
+++ b/lib/bouncer/preemptive_rules.rb
@@ -6,6 +6,19 @@ module Bouncer
     FLOODS_PATHS = [
       '/homeandleisure/floods/cy/34678.aspx',
       '/homeandleisure/floods/34678.aspx',
+      '/homeandleisure/floods/34681.aspx',
+      '/homeandleisure/floods/cy/34681.aspx',
+      '/homeandleisure/floods/147053.aspx',
+      '/homeandleisure/floods/cy/147053.aspx',
+      '/homeandleisure/floods/riverlevels/notactive.aspx',
+      '/homeandleisure/floods/riverlevels/cy/notactive.aspx',
+      '/homeandleisure/floods/riverlevels/riverstation.aspx',
+      '/homeandleisure/floods/riverlevels/cy/riverstation.aspx',
+    ]
+
+    FLOODS_REGEXES = [
+      %r{^/homeandleisure/floods/riverlevels/\d+\.aspx$},
+      %r{^/homeandleisure/floods/riverlevels/cy/\d+\.aspx$},
     ]
 
     def self.redirect(location)
@@ -14,8 +27,10 @@ module Bouncer
 
     def self.try(context, renderer)
       request = context.request
-      if request.host == 'www.environment-agency.gov.uk' && FLOODS_PATHS.include?(request.path)
-        redirect("http://flood.environment-agency.gov.uk#{request.non_canonicalised_fullpath}")
+      if request.host == 'www.environment-agency.gov.uk'
+        if FLOODS_PATHS.include?(request.path) || FLOODS_REGEXES.any? { |regex| regex =~ request.path }
+          redirect("http://flood.environment-agency.gov.uk#{request.non_canonicalised_fullpath}")
+        end
       end
     end
   end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -707,6 +707,24 @@ describe 'HTTP request handling' do
         its(:location) { should  == 'http://flood.environment-agency.gov.uk/homeandleisure/floods/cy/34678.aspx?type=Region&term=Wales&Severity=1' }
       end
 
+      describe 'River Levels redirects' do
+        before do
+          get 'http://www.environment-agency.gov.uk/homeandleisure/floods/riverlevels/120691.aspx?foo=bar'
+        end
+
+        it_behaves_like 'a redirect'
+        its(:location) { should == 'http://flood.environment-agency.gov.uk/homeandleisure/floods/riverlevels/120691.aspx?foo=bar'}
+      end
+
+      describe 'River Levels redirects (Welsh)' do
+        before do
+          get 'http://www.environment-agency.gov.uk/homeandleisure/floods/riverlevels/cy/120691.aspx?foo=bar'
+        end
+
+        it_behaves_like 'a redirect'
+        its(:location) { should == 'http://flood.environment-agency.gov.uk/homeandleisure/floods/riverlevels/cy/120691.aspx?foo=bar' }
+      end
+
       describe 'overrides any mapping (PreemptiveRules)' do
         before do
           path = '/homeandleisure/floods/34678.aspx?page=1'


### PR DESCRIPTION
- This deals with `floods/riverlevels/MULTIPLE_DECIMALS.aspx` and their
  Welsh equivalents in a regex.

I paired with @jamiecobbett on this.
