### PR TITLE
Bump optic14n to match Transition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'aws-ses', '0.5.0'
 gem 'mysql2', '0.3.11'
 gem 'nokogiri', '1.6.0'
 gem 'rack', '1.5.2'
-gem 'optic14n', '1.0.0' # Ideally version should be synced with Transition
+gem 'optic14n', '2.0.0' # Ideally version should be synced with Transition
 gem 'erubis', '2.7.0'
 gem 'airbrake', '3.1.15'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    addressable (2.3.5)
+    addressable (2.3.6)
     airbrake (3.1.15)
       builder
       multi_json
@@ -54,7 +54,7 @@ GEM
     mysql2 (0.3.11)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
-    optic14n (1.0.0)
+    optic14n (2.0.0)
       addressable (~> 2.3)
     polyglot (0.3.3)
     rack (1.5.2)
@@ -99,7 +99,7 @@ DEPENDENCIES
   mr-sparkle (= 0.2.0)
   mysql2 (= 0.3.11)
   nokogiri (= 1.6.0)
-  optic14n (= 1.0.0)
+  optic14n (= 2.0.0)
   rack (= 1.5.2)
   rack-test (= 0.6.2)
   rake (= 10.1.0)


### PR DESCRIPTION
Can be merged independently of: https://github.com/alphagov/transition/pull/229

There is no pressing need for Bouncer to have the upgraded gem, but it is a good thing for them to be in sync.
