### PR TITLE
Remove gemfury gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org/'
-source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 gem 'activerecord', '4.0.2' # This is a mismatch for Transition, which has 3.2.x
 gem 'mysql2', '0.3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     activemodel (4.0.2)
       activesupport (= 4.0.2)


### PR DESCRIPTION
Now that we're using a version of optic14n that is available on rubygems.org,
we don't need to get it from gemfury. This should speed up bundling times.
