### PR TITLE
Update Environment Agency flood rule redirects

### DIFF
--- a/lib/bouncer/preemptive_rules.rb
+++ b/lib/bouncer/preemptive_rules.rb
@@ -10,8 +10,8 @@ module Bouncer
     def self.try(context, renderer)
       request = context.request
       if request.host == 'www.environment-agency.gov.uk'
-        if request.non_canonicalised_fullpath =~ %r{^/homeandleisure/floods/riverlevels/(.*)$}i
-          redirect("http://apps.environment-agency.gov.uk/river-and-sea-levels/#{$1}")
+        if request.non_canonicalised_fullpath =~ %r{^/homeandleisure/floods/riverlevels(/.*)?$}i
+          redirect("http://apps.environment-agency.gov.uk/river-and-sea-levels#{$1}")
         elsif request.non_canonicalised_fullpath =~ %r{^/homeandleisure/floods/((cy/)?(34678|34681|147053)\.aspx(\?.*)?)$}i
           redirect("http://apps.environment-agency.gov.uk/flood/#{$1}")
         end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -740,6 +740,26 @@ describe 'HTTP request handling' do
         its(:location) { should == 'http://apps.environment-agency.gov.uk/river-and-sea-levels/cy/120691.aspx?foo=bar' }
       end
 
+      describe 'river levels homepage' do
+        describe 'with trailing slash' do
+          before do
+            get 'http://www.environment-agency.gov.uk/homeandleisure/floods/riverlevels/'
+          end
+
+          it_behaves_like 'a redirect'
+          its(:location) { should == 'http://apps.environment-agency.gov.uk/river-and-sea-levels/' }
+        end
+
+        describe 'without trailing slash' do
+          before do
+            get 'http://www.environment-agency.gov.uk/homeandleisure/floods/riverlevels'
+          end
+
+          it_behaves_like 'a redirect'
+          its(:location) { should == 'http://apps.environment-agency.gov.uk/river-and-sea-levels' }
+        end
+      end
+
       describe 'overrides any mapping (PreemptiveRules)' do
         before do
           path = '/homeandleisure/floods/34678.aspx?page=1'


### PR DESCRIPTION
- The Environment Agency have finalised the new URLs.

(Paired with @jamiecobbett on this.)
