### PR TITLE
Add missing whitelist entry for Environment Agency

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -30,6 +30,7 @@ www.eblex.org.uk
 www.educationuk.org
 www.electoralcommission.org.uk
 www.esd.org.uk
+www.flytippingactionwales.org
 www.getsafeonline.org
 www.greendealorb.co.uk
 www.highwaysefficiency.org.uk


### PR DESCRIPTION
Currently causing a 501/500 error when this URL is visited: http://www.environment-agency.gov.uk/subjects/waste/1029679/1032559/
