### PR TITLE
Add www.ceh.ac.uk to whitelist for EA

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -1,4 +1,4 @@
-# Contains whitelist of domains which may be used in a New Url. 
+# Contains whitelist of domains which may be used in a New Url.
 # In addition, New Url can include anything on:
 ## *.gov.uk
 ## *.mod.uk


### PR DESCRIPTION
54 Environment Agency mappings, almost all for /hiflows\* paths,
redirect to http://www.ceh.ac.uk/data/nrfa/peakflow_overview.html
