### PR TITLE
Add www.siriusprogramme.com to whitelist

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -66,6 +66,7 @@ www.people1st.co.uk
 www.police.uk
 www.power.nsacademy.co.uk
 www.process.nsacademy.co.uk
+www.siriusprogramme.com
 www.sportactivensa.co.uk
 www.talentretention.biz
 www.techcityuk.com


### PR DESCRIPTION
For www.ukti.gov.uk/siriusprogramme
