### PR TITLE
At the time of parsing a URL, encode square brackets if they exist

### DIFF
--- a/lib/bouncer/outcome/base.rb
+++ b/lib/bouncer/outcome/base.rb
@@ -15,7 +15,7 @@ module Bouncer
       end
 
       def legal_redirect?(url)
-        host = URI.parse(url).host
+        host = URI.parse(url.gsub('[','%5B').gsub(']','%5D')).host
         host.end_with?('.gov.uk') || host.end_with?('.mod.uk') || whitelist.include?(host)
       end
 


### PR DESCRIPTION
- Fix Bouncer 500ing if a URL contains square brackets, eg some ea-publications URLs.
