### PR TITLE
[DVLA] Add www.snapsurveys.com to whitelist

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -67,6 +67,7 @@ www.police.uk
 www.power.nsacademy.co.uk
 www.process.nsacademy.co.uk
 www.siriusprogramme.com
+www.snapsurveys.com
 www.sportactivensa.co.uk
 www.talentretention.biz
 www.techcityuk.com


### PR DESCRIPTION
This is being used to do exit surveys on some DVLA content (transactions?).
