### PR TITLE
Append the request path when the site has it set

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -180,6 +180,7 @@ CREATE TABLE `sites` (
   `managed_by_transition` tinyint(1) NOT NULL DEFAULT '1',
   `launch_date` date DEFAULT NULL,
   `special_redirect_strategy` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `global_redirect_append_path` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sites_on_site` (`abbr`),
   KEY `index_sites_on_organisation_id` (`organisation_id`)
@@ -316,3 +317,5 @@ INSERT INTO schema_migrations (version) VALUES ('20140417100412');
 INSERT INTO schema_migrations (version) VALUES ('20140422160500');
 
 INSERT INTO schema_migrations (version) VALUES ('20140422184036');
+
+INSERT INTO schema_migrations (version) VALUES ('20140502160711');

--- a/lib/bouncer/outcome/global_http_status.rb
+++ b/lib/bouncer/outcome/global_http_status.rb
@@ -4,7 +4,13 @@ module Bouncer
       def serve
         case context.site.global_http_status
         when '301'
-          guarded_redirect(context.site.global_new_url)
+          new_url = if context.site.global_redirect_append_path
+            File.join(context.site.global_new_url,
+                      context.request.non_canonicalised_fullpath)
+          else
+            context.site.global_new_url
+          end
+          guarded_redirect(new_url)
         when '410'
           [410, { 'Content-Type' => 'text/html' }, [renderer.render(context, 410)]]
         else

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -334,6 +334,16 @@ describe 'HTTP request handling' do
         its(:location) { should == 'http://www.gov.uk/global-new' }
       end
 
+      describe 'sites where we append the original path' do
+        before do
+          site.update_attribute(:global_redirect_append_path, true)
+          get 'http://www.minitrue.gov.uk/my-page'
+        end
+
+        it_behaves_like 'a redirect'
+        its(:location) { should == 'http://www.gov.uk/global-new/my-page' }
+      end
+
       describe 'visiting a /404 URL' do
         before do
           get 'http://www.minitrue.gov.uk/404'


### PR DESCRIPTION
As a transitioneer
I would like to map whole legacy domains to subsections of my site 
So that I can avoid duplicated mapping work

Example http://www.ukspaceagency.bis.gov.uk/* became http://www.bis.gov.uk/ukspaceagency/* before GOV.UK existed. It would be useful to us to be able to redirect all traffic to the older domain to the path on the newer domain, so that we only need one mapping, not two.

The (Transition PR)[https://github.com/alphagov/transition/pull/272] will need to be deployed first because it has the schema changes.
