### PR TITLE
Disable Single Table Inheritance so that the new type column can be used

### DIFF
--- a/lib/mapping.rb
+++ b/lib/mapping.rb
@@ -1,2 +1,3 @@
 class Mapping < ActiveRecord::Base
+  self.inheritance_column = nil
 end


### PR DESCRIPTION
This needs to be deployed before anything else here and before https://github.com/alphagov/transition/pull/286.
