### PR TITLE
Add www.fca.org.uk to the whitelist

### DIFF
--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -41,6 +41,7 @@ www.educationuk.org
 www.eventbrite.co.uk
 www.electoralcommission.org.uk
 www.esd.org.uk
+www.fca.org.uk
 www.flytippingactionwales.org
 www.future-leaders.org.uk
 www.getsafeonline.org


### PR DESCRIPTION
This is the Financial Conduct Authority, which redirects from OFT.
