### PR TITLE
Use the new Site.global_type column

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -83,29 +83,29 @@ CREATE TABLE `mappings` (
 
 CREATE TABLE `mappings_batch_entries` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `path` varchar(2048) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `path` varchar(2048) DEFAULT NULL,
   `mappings_batch_id` int(11) DEFAULT NULL,
   `mapping_id` int(11) DEFAULT NULL,
   `processed` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_mappings_batch_entries_on_mappings_batch_id` (`mappings_batch_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `mappings_batches` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `tag_list` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `new_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `tag_list` varchar(255) DEFAULT NULL,
+  `new_url` varchar(255) DEFAULT NULL,
   `update_existing` tinyint(1) DEFAULT NULL,
   `user_id` int(11) DEFAULT NULL,
   `site_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `state` varchar(255) COLLATE utf8_unicode_ci DEFAULT 'unqueued',
+  `state` varchar(255) DEFAULT 'unqueued',
   `seen_outcome` tinyint(1) DEFAULT '0',
-  `type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `type` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_mappings_batches_on_user_id_and_site_id` (`user_id`,`site_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `mappings_staging` (
   `old_url` mediumtext COLLATE utf8_unicode_ci,
@@ -148,7 +148,7 @@ CREATE TABLE `organisations_sites` (
   `site_id` int(11) NOT NULL,
   `organisation_id` int(11) NOT NULL,
   UNIQUE KEY `index_organisations_sites_on_site_id_and_organisation_id` (`site_id`,`organisation_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
@@ -157,14 +157,14 @@ CREATE TABLE `schema_migrations` (
 
 CREATE TABLE `sessions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `session_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `data` text COLLATE utf8_unicode_ci,
+  `session_id` varchar(255) NOT NULL,
+  `data` text,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_sessions_on_session_id` (`session_id`),
   KEY `index_sessions_on_updated_at` (`updated_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `sites` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -181,6 +181,7 @@ CREATE TABLE `sites` (
   `launch_date` date DEFAULT NULL,
   `special_redirect_strategy` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `global_redirect_append_path` tinyint(1) NOT NULL DEFAULT '0',
+  `global_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sites_on_site` (`abbr`),
   KEY `index_sites_on_organisation_id` (`organisation_id`)
@@ -339,3 +340,9 @@ INSERT INTO schema_migrations (version) VALUES ('20140515135431');
 INSERT INTO schema_migrations (version) VALUES ('20140520154514');
 
 INSERT INTO schema_migrations (version) VALUES ('20140523100338');
+
+INSERT INTO schema_migrations (version) VALUES ('20140528161617');
+
+INSERT INTO schema_migrations (version) VALUES ('20140529130515');
+
+INSERT INTO schema_migrations (version) VALUES ('20140529164329');

--- a/lib/bouncer.rb
+++ b/lib/bouncer.rb
@@ -18,7 +18,7 @@ require 'bouncer/fallback_rules'
 require 'bouncer/preemptive_rules'
 
 require 'bouncer/outcome/base'
-require 'bouncer/outcome/global_http_status'
+require 'bouncer/outcome/global_type'
 require 'bouncer/outcome/healthcheck'
 require 'bouncer/outcome/unrecognised_host'
 require 'bouncer/outcome/robots'

--- a/lib/bouncer/app.rb
+++ b/lib/bouncer/app.rb
@@ -18,8 +18,8 @@ module Bouncer
                   Outcome::Sitemap
                 when context.request.path == '/robots.txt'
                   Outcome::Robots
-                when context.site.global_http_status
-                  Outcome::GlobalHTTPStatus
+                when context.site.global_type
+                  Outcome::GlobalType
                 when context.request.path == '' # after c14n, '' is equivalent to '/'
                   Outcome::Homepage
                 else

--- a/lib/bouncer/outcome/global_type.rb
+++ b/lib/bouncer/outcome/global_type.rb
@@ -1,9 +1,9 @@
 module Bouncer
   module Outcome
-    class GlobalHTTPStatus < Base
+    class GlobalType < Base
       def serve
-        case context.site.global_http_status
-        when '301'
+        case context.site.global_type
+        when 'redirect'
           new_url = if context.site.global_redirect_append_path
             File.join(context.site.global_new_url,
                       context.request.non_canonicalised_fullpath)
@@ -11,10 +11,10 @@ module Bouncer
             context.site.global_new_url
           end
           guarded_redirect(new_url)
-        when '410'
+        when 'archive'
           [410, { 'Content-Type' => 'text/html' }, [renderer.render(context, 410)]]
         else
-          message = "Can't serve unexpected global_http_status: #{context.site.global_http_status} for #{context.site.abbr}"
+          message = "Can't serve unexpected global_type: #{context.site.global_type} for #{context.site.abbr}"
           [500, { 'Content-Type' => 'text/plain'}, [message]]
         end
       end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -325,10 +325,10 @@ describe 'HTTP request handling' do
     its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20130724103251/http://www.miniluv.gov.uk">UK Government Web Archive</a>' }
   end
 
-  describe 'sites with global_http_statuses' do
+  describe 'sites with global types' do
     describe 'sites with global redirects' do
       before do
-        site.update_attribute(:global_http_status, '301')
+        site.update_attribute(:global_type, 'redirect')
         site.update_attribute(:global_new_url, 'http://www.gov.uk/global-new')
       end
 
@@ -405,9 +405,9 @@ describe 'HTTP request handling' do
       end
     end
 
-    describe 'sites with global 410' do
+    describe 'sites with global archive' do
       before do
-        site.update_attribute(:global_http_status, '410')
+        site.update_attribute(:global_type, 'archive')
       end
 
       describe 'visiting the homepage' do
@@ -443,9 +443,9 @@ describe 'HTTP request handling' do
       end
     end
 
-    describe 'sites with an unexpected global status' do
+    describe 'sites with an unexpected global type' do
       before do
-        site.update_attribute(:global_http_status, '999')
+        site.update_attribute(:global_type, 'nonsense')
         get 'http://www.minitrue.gov.uk'
       end
 

--- a/spec/units/bouncer/app_spec.rb
+++ b/spec/units/bouncer/app_spec.rb
@@ -44,7 +44,7 @@ describe Bouncer::App do
       host.stub site: site
       site.stub mappings: mappings
       site.stub query_params: nil
-      site.stub global_http_status: nil
+      site.stub global_type: nil
       mappings.stub find_by: mapping
     end
 


### PR DESCRIPTION
...instead of global_http_status. This also includes Transition's
current db/structure.sql, which has some bits of accidentally-committed
collation diff, but since that should be sorted out in transition first
I've copied it all over as-is.
