### PR TITLE
Remove detailed spec output

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --color
---format d


### PR DESCRIPTION
It's really noisy and doesn't add anything. The default still prints out the
test failures, which is what you're interested in.

This also makes it consistent with Transition.
