### PR TITLE
Use site titles, homepages and FURLs on 410s

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -187,6 +187,8 @@ CREATE TABLE `sites` (
   `special_redirect_strategy` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `global_redirect_append_path` tinyint(1) NOT NULL DEFAULT '0',
   `global_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `homepage_title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `homepage_furl` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sites_on_site` (`abbr`),
   KEY `index_sites_on_organisation_id` (`organisation_id`)
@@ -362,3 +364,5 @@ INSERT INTO schema_migrations (version) VALUES ('20140618092821');
 INSERT INTO schema_migrations (version) VALUES ('20140618145219');
 
 INSERT INTO schema_migrations (version) VALUES ('20140623135055');
+
+INSERT INTO schema_migrations (version) VALUES ('20140724164511');

--- a/lib/bouncer/request_context.rb
+++ b/lib/bouncer/request_context.rb
@@ -35,10 +35,10 @@ module Bouncer
       organisation = site.organisation
 
       {
-        homepage: organisation.homepage,
-        title: organisation.title,
+        homepage: site.homepage,
+        title: site.homepage_title || organisation.title,
         css: organisation.css,
-        furl: organisation.furl,
+        furl: site.homepage_furl,
         host: host.hostname,
         tna_timestamp: site.tna_timestamp.try(:strftime, '%Y%m%d%H%M%S'),
         request_uri: request.non_canonicalised_fullpath,

--- a/spec/units/bouncer/app_spec.rb
+++ b/spec/units/bouncer/app_spec.rb
@@ -37,7 +37,7 @@ describe Bouncer::App do
     let(:host)         { double('host').as_null_object }
     let(:path_hash)    { double 'path hash' }
     let(:organisation) { double('organisation').as_null_object }
-    let(:site)         { double 'site' }
+    let(:site)         { double('site').as_null_object }
     let(:mappings)     { double 'mappings' }
 
     before(:each) do


### PR DESCRIPTION
MUST BE MERGED AND DEPLOYED AFTER https://github.com/alphagov/transition/pull/353

Sites can already have homepages which differ from their owning organisation's
homepage. Given that the furl attribute is simply a shorter form of the full
URL for a site, it follows that they have furls too.

We are currently inconsistent with how we apply the (new) homepage for a site.
- If you look at the site in Transition, it says the new homepage is the one
  specified for that site in Redirector.
- If you visit the old homepage, you get redirected to the site's new
  homepage, which is correct.
- However, if you visit a page with an archive/unresolved mapping, it links
  to the organisation's new homepage, which is unhelpful or even
  inappropriate.

Therefore, we should change Bouncer's archive behaviour so that it links to the
site's new homepage. To make it consistent, we then need to make it use the
furl (if any) and a title which describes the site, rather than the
organisation. If the site has no title, use the organisation's title.
