### PR TITLE
Remove some #try from attributes_for_render

### DIFF
--- a/lib/bouncer/request_context.rb
+++ b/lib/bouncer/request_context.rb
@@ -31,16 +31,16 @@ module Bouncer
     end
 
     def attributes_for_render
-      site = host.try(:site)
-      organisation = site.try(:organisation)
+      site = host.site
+      organisation = site.organisation
 
       {
-        homepage: organisation.try(:homepage),
-        title: organisation.try(:title),
-        css: organisation.try(:css),
-        furl: organisation.try(:furl),
-        host: host.try(:hostname),
-        tna_timestamp: site.try(:tna_timestamp).try(:strftime, '%Y%m%d%H%M%S'),
+        homepage: organisation.homepage,
+        title: organisation.title,
+        css: organisation.css,
+        furl: organisation.furl,
+        host: host.hostname,
+        tna_timestamp: site.tna_timestamp.try(:strftime, '%Y%m%d%H%M%S'),
         request_uri: request.non_canonicalised_fullpath,
         suggested_url: mapping.try(:suggested_url),
         archive_url: mapping.try(:archive_url)

--- a/spec/units/bouncer/app_spec.rb
+++ b/spec/units/bouncer/app_spec.rb
@@ -34,17 +34,20 @@ describe Bouncer::App do
   end
 
   context 'when the host is recognised' do
-    let(:host) { double 'host' }
-    let(:path_hash) { double 'path hash' }
-    let(:site) { double 'site' }
-    let(:mappings) { double 'mappings' }
+    let(:host)         { double('host').as_null_object }
+    let(:path_hash)    { double 'path hash' }
+    let(:organisation) { double('organisation').as_null_object }
+    let(:site)         { double 'site' }
+    let(:mappings)     { double 'mappings' }
 
     before(:each) do
       Digest::SHA1.stub hexdigest: path_hash
       host.stub site: site
-      site.stub mappings: mappings
-      site.stub query_params: nil
-      site.stub global_type: nil
+      site.stub mappings: mappings,
+                query_params: nil,
+                global_type: nil,
+                organisation: organisation,
+                tna_timestamp: nil
       mappings.stub find_by: mapping
     end
 


### PR DESCRIPTION
- By the time we're here, we're at a recognised host, which necessarily
  implies an associated site and org
- Some things may still not be there, but those things are limited to:
  - A mapping (implies 404)
  - A TNA timestamp (implies nothing very much, as a default will be generated)

**Note** some extra stubbing is required. To minimise this, use `as_null_object` (not doing so requires an extra half-dozen stubs and increases test brittleness). We care about actual calls to `site`, so we can't avoid being explicit about what will be called there. Add those calls.
