### PR TITLE
Link to the page not the homepage on TNA for a 404

### DIFF
--- a/lib/bouncer/request_context.rb
+++ b/lib/bouncer/request_context.rb
@@ -31,24 +31,24 @@ module Bouncer
     end
 
     def attributes_for_render
-      site = host.site
-      organisation = site.organisation
-
       {
         homepage: organisation.homepage,
         title: organisation.title,
         css: organisation.css,
         furl: organisation.furl,
         host: host.hostname,
-        tna_timestamp: site.tna_timestamp.try(:strftime, '%Y%m%d%H%M%S'),
-        request_uri: request.non_canonicalised_fullpath,
         suggested_url: mapping.try(:suggested_url),
-        archive_url: mapping.try(:archive_url)
+        archive_url: mapping.try(:archive_url) || default_archive_url
       }
     end
 
     def render_binding
       RenderingContext.new(attributes_for_render).render_binding
+    end
+
+    def default_archive_url
+      tna_timestamp = site.tna_timestamp.try(:strftime, '%Y%m%d%H%M%S')
+      "http://webarchive.nationalarchives.gov.uk/#{tna_timestamp}/http://#{host.hostname}#{request.non_canonicalised_fullpath}"
     end
   end
 end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -315,7 +315,7 @@ describe 'HTTP request handling' do
     its(:body) { should include '<title>404 - Not Found</title>' }
     its(:body) { should include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
     its(:body) { should include '<div class="organisation ministry-of-truth">' }
-    its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk">UK Government Web Archive</a>' }
+    its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/an-unrecognised-page">UK Government Web Archive</a>' }
   end
 
   describe 'visiting an unrecognised path on a different recognised host' do
@@ -334,7 +334,7 @@ describe 'HTTP request handling' do
     its(:body) { should include '<title>404 - Not Found</title>' }
     its(:body) { should include '<a href="http://www.gov.uk/government/organisations/ministry-of-love"><span>Ministry of Love</span></a>' }
     its(:body) { should include '<div class="organisation ministry-of-love">' }
-    its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20130724103251/http://www.miniluv.gov.uk">UK Government Web Archive</a>' }
+    its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20130724103251/http://www.miniluv.gov.uk/an-unrecognised-page">UK Government Web Archive</a>' }
   end
 
   describe 'sites with global types' do
@@ -477,7 +477,7 @@ describe 'HTTP request handling' do
     its(:body) { should include '<title>404 - Not Found</title>' }
     its(:body) { should include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
     its(:body) { should include '<div class="organisation ministry-of-truth">' }
-    its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk">UK Government Web Archive</a>' }
+    its(:body) { should include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/404">UK Government Web Archive</a>' }
   end
 
   describe 'escaping Database content in the 404 page' do

--- a/templates/404.erb
+++ b/templates/404.erb
@@ -29,7 +29,7 @@
             </h2>
             <p>Please check that you have entered the correct web address.</p>
             <p>The information you need may be found on <a href="https://www.gov.uk">GOV.UK</a>
-                or in <a href="http://webarchive.nationalarchives.gov.uk/<%= tna_timestamp %>/http://<%= host %>">UK Government Web Archive</a>.</p>
+                or in <a href="<%= archive_url %>">UK Government Web Archive</a>.</p>
             <p><a href="https://www.gov.uk/support">Our support pages</a> have answers to the most common questions about GOV.UK.
             You can use the <a href="https://www.gov.uk/feedback/contact">contact form</a> to ask a question, report a problem or suggest an improvement.</p>
           </div>

--- a/templates/410.erb
+++ b/templates/410.erb
@@ -1,4 +1,3 @@
-<% archive_link = archive_url || "http://webarchive.nationalarchives.gov.uk/#{tna_timestamp}/http://#{host}#{request_uri}" %>
 <!DOCTYPE html>
 <html class="no-branding">
   <head>
@@ -26,10 +25,10 @@
               <div class="organisation <%= css || "no-organisation" %>">
                 <a href="<%= homepage %>"><span><%= title %></span></a>
               </div>
-              <a href="<%= archive_link %>">This item has been archived</a>
+              <a href="<%= archive_url %>">This item has been archived</a>
             </h2>
             <p class="either-or">You can either</p>
-            <p class="call-to-action"><a href="<%= archive_link %>">View the item you were looking for</a> in the UK Government Web Archive</p>
+            <p class="call-to-action"><a href="<%= archive_url %>">View the item you were looking for</a> in the UK Government Web Archive</p>
             <p class="either-or">or</p>
             <p class="call-to-action">Visit the new <%= title %> site at <a href="<%= homepage %>"><%= furl || homepage %></a></p>
             <% if suggested_url %>


### PR DESCRIPTION
We currently link to the TNA page for the domain, rather than the TNA page for the page you requested. When this behaviour was originally chosen, the assumption may have been that the page probably isn't in the archive, so linking to the archive for the homepage was a better option.

If I am correct about the origins of this behaviour, then it may have been when we thought our coverage would be excellent. That is not generally the case.
