### PR TITLE
Use ' instead of " around the mr-sparkle gem for consistency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :production do
 end
 
 group :development do
-  gem "mr-sparkle", '0.2.0'
+  gem 'mr-sparkle', '0.2.0'
 end
 
 group :test do


### PR DESCRIPTION
I'm really on a consistency drive today. :-(
