### PR TITLE
Update MCGA site rules

### DIFF
--- a/lib/bouncer/preemptive_rules.rb
+++ b/lib/bouncer/preemptive_rules.rb
@@ -33,6 +33,8 @@ module Bouncer
           redirect("http://www.dft.gov.uk/mca/#{$1}")
         when %r{^/mca/(.*)$}
           redirect("http://www.dft.gov.uk/mca/#{$1}")
+        when %r{^/(.*)$}
+          redirect("http://www.dft.gov.uk/mca/#{$1}")
         end
       end
 

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -865,7 +865,7 @@ describe 'HTTP request handling' do
     describe 'Marine Coastguard Agency' do
       before { site.hosts.create hostname: 'www.mcga.gov.uk' }
 
-      describe '/c4mca/ redirects' do
+      describe 'paths beginning with /c4mca/' do
         before do
           get 'http://www.mcga.gov.uk/c4mca/mcga07-home/shipsandcargoes/mcga-shipsregsandguidance.htm'
         end
@@ -874,7 +874,7 @@ describe 'HTTP request handling' do
         its(:location) { should == 'http://www.dft.gov.uk/mca/mcga07-home/shipsandcargoes/mcga-shipsregsandguidance.htm' }
       end
 
-      describe '/mca/ redirects' do
+      describe 'paths beginning with /mca/' do
         before do
           get 'http://www.mcga.gov.uk/mca/msn1693.pdf'
         end
@@ -883,14 +883,13 @@ describe 'HTTP request handling' do
         its(:location) { should == 'http://www.dft.gov.uk/mca/msn1693.pdf' }
       end
 
-      describe 'other paths use mappings' do
+      describe 'all other paths' do
         before do
-          path = '/hydrography'
-          site.mappings.create(path: path, path_hash: Digest::SHA1.hexdigest(path), type: 'archive')
-          get "http://www.mcga.gov.uk#{path}"
+          get 'http://www.mcga.gov.uk/hydrography'
         end
 
-        it_behaves_like 'a 410'
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.dft.gov.uk/mca/hydrography' }
       end
     end
 


### PR DESCRIPTION
The rules added in 767a7eefe80408b0856c9a7ced0daf1a02bdbfea and
599d934da9e615ad13f70a2c1c02b6660e6ea029 are not being used at the
moment because the site is configured as a global redirect appending
path to www.dft.gov.uk/mca. Because the global type case comes before
the Outcome::Status (which would use the rules otherwise) in app.rb
we aren't getting the behaviour we want.

This change adds a pre-emptive rule to replicate a global-path preserving
redirect, with the intent that the path-preserving config will be removed.
