### PR TITLE
Fallback rules for GovStore/Digital Marketplace paths

### DIFF
--- a/lib/bouncer/fallback_rules.rb
+++ b/lib/bouncer/fallback_rules.rb
@@ -29,6 +29,10 @@ module Bouncer
         redirect("https://gds.blog.gov.uk/#{$1}")
       elsif request.host == 'govstore.service.gov.uk' && request.path =~ %r{^/cloudstore/supplier/}
         redirect("https://www.gov.uk/digital-marketplace")
+      elsif request.host == 'govstore.service.gov.uk' && request.path =~ %r{^/cloudstore/([_0-9a-zA-Z-]+)$}
+        redirect("http://www.digitalmarketplace.service.gov.uk/service/#{$1}")
+      elsif request.host == 'govstore.service.gov.uk' && request.path =~ %r{^/cloudstore(/[ips]aas|/scs)(/[_0-9a-zA-Z-]+){0,2}/([_0-9a-zA-Z-]+)$}
+        redirect("http://www.digitalmarketplace.service.gov.uk/service/#{$3}")
       end
     end
   end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -932,16 +932,52 @@ describe 'HTTP request handling' do
       end
     end
 
-    describe 'GovStore redirects' do
+    describe 'GovStore/CloudStore fallback rules' do
       before { site.hosts.create hostname: 'govstore.service.gov.uk' }
 
-      describe 'visiting a /cloudstore/supplier/* URL' do
+      context 'visiting a /cloudstore/supplier/* URL' do
         before do
           get 'http://govstore.service.gov.uk/cloudstore/supplier/a_supplier'
         end
 
         it_behaves_like 'a 301'
         its(:location) { should == 'https://www.gov.uk/digital-marketplace' }
+      end
+
+      context 'visiting a /cloudstore/service-id URL' do
+        before do
+          get 'http://govstore.service.gov.uk/cloudstore/5-g5-0722-028'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.digitalmarketplace.service.gov.uk/service/5-g5-0722-028' }
+      end
+
+      context 'visiting a /cloudstore/category/service-id URL' do
+        before do
+          get 'http://govstore.service.gov.uk/cloudstore/scs/5-g5-0722-028'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.digitalmarketplace.service.gov.uk/service/5-g5-0722-028' }
+      end
+
+      context 'visiting a /cloudstore/category/sub-category/service-id URL' do
+        before do
+          get 'http://govstore.service.gov.uk/cloudstore/iaas/sub-category/5-g5-0722-028'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.digitalmarketplace.service.gov.uk/service/5-g5-0722-028' }
+      end
+
+      context 'visiting a /cloudstore/category/sub-category/sub-sub-category/service-id URL' do
+        before do
+          get 'http://govstore.service.gov.uk/cloudstore/iaas/sub-category/sub-sub-category/5-g5-0722-028'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.digitalmarketplace.service.gov.uk/service/5-g5-0722-028' }
       end
     end
   end


### PR DESCRIPTION
These rules are for:
  `/cloudstore/supplier/*`,
  `/cloudstore/service-id`,
  `/cloudstore/category/service-id`,
  `/cloudstore/category/sub-category/service-id` and
  `/cloudstore/category/sub-category/sub-sub-category/service-id`.
