### PR TITLE
Add a GovStore fallback rule to redirect /* to its GOV.UK start page

### DIFF
--- a/lib/bouncer/fallback_rules.rb
+++ b/lib/bouncer/fallback_rules.rb
@@ -27,12 +27,12 @@ module Bouncer
         redirect("http://www.hm-treasury.gov.uk/#{$1}")
       elsif request.host == 'digital.cabinetoffice.gov.uk' && request.path =~ %r{^/(.*)$}
         redirect("https://gds.blog.gov.uk/#{$1}")
-      elsif request.host == 'govstore.service.gov.uk' && request.path =~ %r{^/cloudstore/supplier/}
-        redirect("https://www.gov.uk/digital-marketplace")
       elsif request.host == 'govstore.service.gov.uk' && request.path =~ %r{^/cloudstore/([_0-9a-zA-Z-]+)$}
         redirect("http://www.digitalmarketplace.service.gov.uk/service/#{$1}")
       elsif request.host == 'govstore.service.gov.uk' && request.path =~ %r{^/cloudstore(/[ips]aas|/scs)(/[_0-9a-zA-Z-]+){0,2}/([_0-9a-zA-Z-]+)$}
         redirect("http://www.digitalmarketplace.service.gov.uk/service/#{$3}")
+      elsif request.host == 'govstore.service.gov.uk'
+        redirect("https://www.gov.uk/digital-marketplace")
       end
     end
   end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -935,15 +935,6 @@ describe 'HTTP request handling' do
     describe 'GovStore/CloudStore fallback rules' do
       before { site.hosts.create hostname: 'govstore.service.gov.uk' }
 
-      context 'visiting a /cloudstore/supplier/* URL' do
-        before do
-          get 'http://govstore.service.gov.uk/cloudstore/supplier/a_supplier'
-        end
-
-        it_behaves_like 'a 301'
-        its(:location) { should == 'https://www.gov.uk/digital-marketplace' }
-      end
-
       context 'visiting a /cloudstore/service-id URL' do
         before do
           get 'http://govstore.service.gov.uk/cloudstore/5-g5-0722-028'
@@ -978,6 +969,15 @@ describe 'HTTP request handling' do
 
         it_behaves_like 'a 301'
         its(:location) { should == 'http://www.digitalmarketplace.service.gov.uk/service/5-g5-0722-028' }
+      end
+
+      context 'visiting a GovStore URL that isn\'t for a supplier in a category or within /cloudstore' do
+        before do
+          get 'http://govstore.service.gov.uk/a'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'https://www.gov.uk/digital-marketplace' }
       end
     end
   end


### PR DESCRIPTION
- If and only if the path does not match any of the previous regexen -
  see
  https://github.com/alphagov/bouncer/commit/c29b447b63389d0b2d7f230565ae1b847481f01d.
- This encompasses /cloudstore/supplier, so delete that rule.
