### PR TITLE
benchmark:all becomes a performance spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-$LOAD_PATH.unshift(File.expand_path('lib', File.dirname(__FILE__)))
-
 require 'airbrake'
 require 'airbrake_tasks'
 
@@ -22,5 +20,3 @@ namespace :errbit do
                          :dry_run        => ENV['DRY_RUN'])
   end
 end
-
-Dir['lib/tasks/**/*.rake'].each {|tasks_file| load tasks_file}

--- a/lib/tasks/benchmark/all.rake
+++ b/lib/tasks/benchmark/all.rake
@@ -1,8 +1,0 @@
-require 'benchmark/all'
-
-namespace :benchmark do
-  desc 'Benchmark a selection of query types'
-  task :all, [:number_of_runs] do |_, args|
-    Benchmark::All.new(args[:number_of_runs]).run!
-  end
-end

--- a/spec/performance/benchmark_spec.rb
+++ b/spec/performance/benchmark_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../boot'
+require_relative '../../lib/benchmark/all'
+
+describe 'Benchmarking', performance: true do
+  include Rack::Test::Methods
+
+  before :all do
+    @app = Rack::Builder.parse_file('config.ru')[0]
+  end
+
+  let(:app)            { @app }
+  let(:number_of_runs) { ENV['NUMBER_OF_RUNS'] || 1000 }
+
+  it 'generates timings for no host, 301, 410, 404' do
+    Benchmark::All.new(number_of_runs).run!
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+  config.filter_run_excluding performance: true
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
- Will stop deploy from falling over trying to load rack/test
- Need to run as `NUMBER_OF_RUNS=1000 bundle exec rspec spec/performance`
