### PR TITLE
Bouncer looks up mappings by path

### DIFF
--- a/lib/bouncer/request_context.rb
+++ b/lib/bouncer/request_context.rb
@@ -15,7 +15,7 @@ module Bouncer
 
     def mapping
       # Reminder: the hash is always calculated on the canonicalize!d request
-      mappings.find_by path_hash: Digest::SHA1.hexdigest(@request.fullpath)
+      mappings.find_by path: @request.fullpath
     end
 
     def mappings

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -645,11 +645,14 @@ describe 'HTTP request handling' do
 
     describe 'parameters without values do not get thrown away' do
       before do
-        path = '/an-archived-page?with&a&weird&querystring'
         site.update_attribute(:query_params, "with:a:weird:querystring")
+
+        path           = '/an-archived-page?with&a&weird&querystring'
+        canonical_path = '/an-archived-page?a&querystring&weird&with'
+
         site.mappings.create \
-          path: path,
-          path_hash:    Digest::SHA1.hexdigest('/an-archived-page?a&querystring&weird&with'),
+          path:         canonical_path,
+          path_hash:    Digest::SHA1.hexdigest(canonical_path),
           type:         'archive'
 
         get "http://www.minitrue.gov.uk#{path}"

--- a/spec/units/bouncer/app_spec.rb
+++ b/spec/units/bouncer/app_spec.rb
@@ -50,11 +50,6 @@ describe Bouncer::App do
     shared_examples 'a redirector which recognises the host' do
       it_should_behave_like 'a redirector'
 
-      it 'should hash the path' do
-        Digest::SHA1.should_receive(:hexdigest).with(path)
-        get url
-      end
-
       it 'should get the host\'s site' do
         host.should_receive(:site).with(no_args)
         get url
@@ -66,7 +61,7 @@ describe Bouncer::App do
       end
 
       it 'should try to find the right mapping' do
-        mappings.should_receive(:find_by).with(path_hash: path_hash)
+        mappings.should_receive(:find_by).with(path: path)
         get url
       end
     end


### PR DESCRIPTION
**DON'T MERGE UNTIL:**

... a deploy of transition has taken place to get the [`UNIQUE INDEX`](https://github.com/alphagov/transition/pull/446) on `mappings (site_id, path)`
- Fix the tests so that `path_hash` is not relied upon
- Don't remove references to `path_hash` in factoried doubles yet -
  we still need them to satisfy the `NOT NULL` constraint
