### PR TITLE
Stop using pgcrypto extension

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23,20 +23,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
---
--- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
-
-
 SET search_path = public, pg_catalog;
 
 SET default_tablespace = '';
@@ -1304,5 +1290,7 @@ INSERT INTO schema_migrations (version) VALUES ('20141118112125');
 INSERT INTO schema_migrations (version) VALUES ('20141118121300');
 
 INSERT INTO schema_migrations (version) VALUES ('20141119113045');
+
+INSERT INTO schema_migrations (version) VALUES ('20141120164444');
 
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -9,7 +9,6 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 dropdb transition_test
 createdb --encoding=UTF8 --template=template0 transition_test
-sudo -u postgres psql -d transition_test -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto'
 cat db/structure.sql | psql -d transition_test
 
 RACK_ENV=test bundle exec rake --trace


### PR DESCRIPTION
We've dropped path_hash so don't need this any more (Bouncer never
relied on it anyway).
