### PR TITLE
Add preemptive redirect rules for Ofsted inspection reports

### DIFF
--- a/lib/bouncer/preemptive_rules.rb
+++ b/lib/bouncer/preemptive_rules.rb
@@ -19,6 +19,14 @@ module Bouncer
           redirect("http://apps.environment-agency.gov.uk/flood/#{$1}")
         end
 
+      when 'www.ofsted.gov.uk'
+        case request.non_canonicalised_fullpath
+        when %r{^/inspection-reports/find-inspection-report/provider/(.*)$}i
+          redirect("http://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/#{$1}")
+        when %r{^/provider/files/(.*)/urn/(.*)$}i
+          redirect("http://reports.ofsted.gov.uk/provider/files/#{$1}/urn/#{$2}")
+        end
+
       when 'www.businesslink.gov.uk'
         case request.non_canonicalised_fullpath
         when %r{^(.*site=230.*)$}i

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -887,6 +887,29 @@ describe 'HTTP request handling' do
       end
     end
 
+    describe 'Ofsted inspection reports redirects' do
+      before { site.hosts.create hostname: 'www.ofsted.gov.uk' }
+
+      describe 'visiting a landing page URL' do
+        before do
+          get 'http://www.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/CARE/EY480906'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/CARE/EY480906' }
+      end
+
+      describe 'visiting a report asset URL' do
+        before do
+          get 'http://www.ofsted.gov.uk/provider/files/1908405/urn/137739.pdf'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://reports.ofsted.gov.uk/provider/files/1908405/urn/137739.pdf' }
+      end
+
+    end
+
     describe 'Treasury redirects' do
       before { site.hosts.create hostname: 'cdn.hm-treasury.gov.uk' }
 


### PR DESCRIPTION
Ofsted has c. 170,000 report pages for various schools and institutions, each with pdfs and other attachments. These will eventually be redeveloped into some sort of a service domain, but are currently excluded from transition as a tool/transaction. These will temporarily be hosted at a subdomain: http://reports.ofsted.gov.uk

This rule prevents the need for the transition tool to contain these 400,000(?) mappings; the site structure is consistent across both namespaces.
