### PR TITLE
Limit sitemaps to 50,000 entries

### DIFF
--- a/lib/bouncer/outcome/sitemap.rb
+++ b/lib/bouncer/outcome/sitemap.rb
@@ -1,14 +1,16 @@
 module Bouncer
   module Outcome
     class Sitemap < Base
+      MAXIMUM_SIZE = 50_000
+
       def serve
         [200, { 'Content-Type' => 'application/xml' }, [build_sitemap.to_xml]]
       end
 
       def build_sitemap
         Nokogiri::XML::Builder.new do |xml|
-          xml.urlset xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9' do
-            context.mappings.where(type: 'redirect').each do |mapping|
+          xml.urlset(xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9') do
+            context.mappings.where(type: 'redirect').order(:id).limit(MAXIMUM_SIZE).each do |mapping|
               url = Addressable::URI.parse(mapping.path).tap do |uri|
                 uri.scheme = 'http'
                 uri.host   = context.request.host

--- a/spec/support/sitemap_matchers.rb
+++ b/spec/support/sitemap_matchers.rb
@@ -24,3 +24,11 @@ RSpec::Matchers.define :have_sitemap_entry_for do |url|
     !sitemap.xpath("/xmlns:urlset/xmlns:url/xmlns:loc[text()='#{url}']").empty?
   end
 end
+
+RSpec::Matchers.define :have_so_many_sitemap_entries do |expected_count|
+  match do |string|
+    sitemap = Nokogiri::XML::Document.parse(string)
+    sitemap.xpath("/xmlns:urlset/xmlns:url/xmlns:loc").count == expected_count
+  end
+end
+


### PR DESCRIPTION
Bouncer's sitemaps include all redirect mappings from that site. This causes
three problems for sites with large numbers of redirect mappings:
- the request takes too long to process, so a 502 is served
- our memory usage jumps on each occasion for the largest sites
- we are violating the sitemap specification, which limits each file to 50,000
  entries

The only downside to this change is that some redirects will not be included in
sitemaps, but we think this is better than not being able to serve a sitemap at
all, or Bouncer running out of memory.

If you need more than 50,000 entries, you should use multiple sitemap files,
like GOV.UK: https://www.gov.uk/sitemap.xml
