### PR TITLE
Use find_in_batches to generate sitemaps

### DIFF
--- a/lib/bouncer/outcome/sitemap.rb
+++ b/lib/bouncer/outcome/sitemap.rb
@@ -2,6 +2,7 @@ module Bouncer
   module Outcome
     class Sitemap < Base
       MAXIMUM_SIZE = 50_000
+      BATCH_SIZE   = 1_000 # Must be smaller than the MAXIMUM_SIZE, or too many could be added on the first loop
 
       def serve
         [200, { 'Content-Type' => 'application/xml' }, [build_sitemap.to_xml]]
@@ -10,15 +11,23 @@ module Bouncer
       def build_sitemap
         Nokogiri::XML::Builder.new do |xml|
           xml.urlset(xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9') do
-            context.mappings.where(type: 'redirect').order(:id).limit(MAXIMUM_SIZE).each do |mapping|
-              url = Addressable::URI.parse(mapping.path).tap do |uri|
-                uri.scheme = 'http'
-                uri.host   = context.request.host
+            index = 0
+            context.mappings.where(type: 'redirect').find_in_batches(batch_size: BATCH_SIZE) do |batch|
+              batch.each do |mapping|
+                url = Addressable::URI.parse(mapping.path).tap do |uri|
+                  uri.scheme = 'http'
+                  uri.host   = context.request.host
+                end
+
+                xml.url do
+                  xml.loc url
+                end
               end
 
-              xml.url do
-                xml.loc url
-              end
+              index = index + BATCH_SIZE
+              # Stop looping (and querying and instantiating objects) when we
+              # get to the maximum batch size
+              break if index >= MAXIMUM_SIZE
             end
           end
         end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -542,9 +542,11 @@ describe 'HTTP request handling' do
 
   describe 'visiting a /sitemap.xml URL for a site with a large number of redirects' do
     let(:maximum_size) { 10 }
+    let(:batch_size) { 5 } # if the batch size is larger than the max, it will always add too many
 
     before do
       stub_const('Bouncer::Outcome::Sitemap::MAXIMUM_SIZE', maximum_size)
+      stub_const('Bouncer::Outcome::Sitemap::BATCH_SIZE', batch_size)
       (1..maximum_size + 1).each do |index|
         site.mappings.create \
         path:         "/a-redirected-page-#{index}",


### PR DESCRIPTION
Whilst limiting the size to 50,000 has reduced the amount of memory consumed
when serving large sitemaps, it hasn't improved it as much as we'd like.

We found that using find_in_batches resulted in much reduced memory usage.

find_in_batches doesn't respect (silently ignores) any limit and ordering used,
hence the jury-rigged `break` code.
