### PR TITLE
Add additional preemptive rules for Ofsted reports

### DIFF
--- a/lib/bouncer/preemptive_rules.rb
+++ b/lib/bouncer/preemptive_rules.rb
@@ -25,6 +25,12 @@ module Bouncer
           redirect("http://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/#{$1}")
         when %r{^/provider/files/(.*)/urn/(.*)$}i
           redirect("http://reports.ofsted.gov.uk/provider/files/#{$1}/urn/#{$2}")
+        when %r{^/oxedu_providers/full/\(?urn\)?/([^/]*)/?(.*)$}i
+          redirect("http://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/ELS/#{$1}")
+        when %r{^/oxcare_providers/full/\(?urn\)?/([^/]*)/?(.*)$}i
+          redirect("http://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/CARE/#{$1}")
+        when %r{^/index.php\?q=filedownloading(.*)$}i
+          redirect("http://reports.ofsted.gov.uk/index.php?q=filedownloading#{$1}")
         end
 
       when 'www.businesslink.gov.uk', 'businesslink.gov.uk'

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -1020,6 +1020,33 @@ describe 'HTTP request handling' do
         its(:location) { should == 'http://reports.ofsted.gov.uk/provider/files/1908405/urn/137739.pdf' }
       end
 
+      describe 'visiting an interstitial asset download URL' do
+        before do
+          get 'http://www.ofsted.gov.uk/index.php?q=filedownloading&id=2150035&type=1&refer=0'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://reports.ofsted.gov.uk/index.php?q=filedownloading&id=2150035&type=1&refer=0' }
+      end
+
+      describe 'visiting an oxedu provider report page URL' do
+        before do
+          get 'http://www.ofsted.gov.uk/oxedu_providers/full/(urn)/136338'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/ELS/136338' }
+      end
+
+      describe 'visiting an oxcare provider report page URL' do
+        before do
+          get 'http://www.ofsted.gov.uk/oxcare_providers/full/(urn)/EY333119/(type)/33/(typename)/Childcare%20on%20Non-Domestic%20Premises'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/CARE/EY333119' }
+      end
+
     end
 
     describe 'Ofsted inspection reports non-www redirects' do


### PR DESCRIPTION
This request handles rules remaining from a previous iteration of the Ofsted reports site and an interstitial file download link. This renders a series of approx 46000 mappings unnecessary, and deletable.
