### PR TITLE
Load only paths, not full mappings, for sitemaps

### DIFF
--- a/lib/bouncer/outcome/sitemap.rb
+++ b/lib/bouncer/outcome/sitemap.rb
@@ -10,8 +10,8 @@ module Bouncer
       def build_sitemap
         Nokogiri::XML::Builder.new do |xml|
           xml.urlset(xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9') do
-            context.mappings.where(type: 'redirect').order(:id).limit(MAXIMUM_SIZE).each do |mapping|
-              url = Addressable::URI.parse(mapping.path).tap do |uri|
+            context.mappings.where(type: 'redirect').order(:id).limit(MAXIMUM_SIZE).pluck(:path).each do |path|
+              url = Addressable::URI.parse(path).tap do |uri|
                 uri.scheme = 'http'
                 uri.host   = context.request.host
               end


### PR DESCRIPTION
This avoids loading mapping objects into memory when we only need
the paths. Numbers from dev with 4GB RAM, using a single unicorn,
after 10 requests:

master: 5-5.5s request time, 8.5% RAM
here: 3.5s request time, 4% RAM
