### PR TITLE
Remove rules for cdn.hm-treasury in favour of config

### DIFF
--- a/lib/bouncer/fallback_rules.rb
+++ b/lib/bouncer/fallback_rules.rb
@@ -28,8 +28,6 @@ module Bouncer
       when 'www.number10.gov.uk', 'number10.gov.uk'
         redirect("http://www.number10.gov.uk/news/#{$4}") if
           request.path =~ %r{^/news/?([_0-9a-zA-Z-]+)?/([0-9]+)/([0-9]+)/(.*)-([0-9]+)$}
-      when 'cdn.hm-treasury.gov.uk'
-        redirect("http://www.hm-treasury.gov.uk/#{$1}") if request.path =~ %r{^/(.*)$}
       when 'digital.cabinetoffice.gov.uk'
         redirect("https://gds.blog.gov.uk/#{$1}") if request.path =~ %r{^/(.*)$}
       when 'govstore.service.gov.uk'

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -1063,19 +1063,6 @@ describe 'HTTP request handling' do
 
     end
 
-    describe 'Treasury redirects' do
-      before { site.hosts.create hostname: 'cdn.hm-treasury.gov.uk' }
-
-      describe 'visiting a CDN /* URL' do
-        before do
-          get 'http://cdn.hm-treasury.gov.uk/budget2013_complete.pdf'
-        end
-
-        it_behaves_like 'a 301'
-        its(:location) { should == 'http://www.hm-treasury.gov.uk/budget2013_complete.pdf' }
-      end
-    end
-
     describe 'GDS blog redirects' do
       before { site.hosts.create hostname: 'digital.cabinetoffice.gov.uk' }
 


### PR DESCRIPTION
This is a complementary change to https://github.com/alphagov/transition-config/pull/1069 and should not be merged/deployed before the database edit task in https://www.pivotaltracker.com/story/show/85004378 has been performed.