### PR TITLE
Remove GDS blog rules

### DIFF
--- a/lib/bouncer/fallback_rules.rb
+++ b/lib/bouncer/fallback_rules.rb
@@ -30,8 +30,6 @@ module Bouncer
           request.path =~ %r{^/news/?([_0-9a-zA-Z-]+)?/([0-9]+)/([0-9]+)/(.*)-([0-9]+)$}
       when 'cdn.hm-treasury.gov.uk'
         redirect("http://www.hm-treasury.gov.uk/#{$1}") if request.path =~ %r{^/(.*)$}
-      when 'digital.cabinetoffice.gov.uk'
-        redirect("https://gds.blog.gov.uk/#{$1}") if request.path =~ %r{^/(.*)$}
       when 'govstore.service.gov.uk'
         case request.path
         when %r{^/cloudstore/([_0-9a-zA-Z-]+)$}

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -1111,19 +1111,6 @@ describe 'HTTP request handling' do
       end
     end
 
-    describe 'GDS blog redirects' do
-      before { site.hosts.create hostname: 'digital.cabinetoffice.gov.uk' }
-
-      describe 'visiting a /* URL' do
-        before do
-          get 'http://digital.cabinetoffice.gov.uk/tag/david-mann'
-        end
-
-        it_behaves_like 'a 301'
-        its(:location) { should == 'https://gds.blog.gov.uk/tag/david-mann' }
-      end
-    end
-
     describe 'GovStore/CloudStore fallback rules' do
       before { site.hosts.create hostname: 'govstore.service.gov.uk' }
 


### PR DESCRIPTION
This is dependent on https://github.com/alphagov/transition-config/pull/1070 and should not be merged or deployed until that config takes effect.