### PR TITLE
Add rules to handle multisurfaced AAIB, MAIB and RAIB content.

### DIFF
--- a/lib/bouncer/preemptive_rules.rb
+++ b/lib/bouncer/preemptive_rules.rb
@@ -33,6 +33,24 @@ module Bouncer
           redirect("http://reports.ofsted.gov.uk/index.php?q=filedownloading#{$1}")
         end
 
+      when 'www.aaib.gov.uk', 'aaib.gov.uk'
+        case request.non_canonicalised_fullpath
+        when %r{^/sites/aaib/(.*)$}i
+          redirect("http://www.aaib.gov.uk/#{$1}")
+        end
+
+      when 'www.maib.gov.uk', 'maib.gov.uk'
+        case request.non_canonicalised_fullpath
+        when %r{^/sites/maib/(.*)$}i
+          redirect("http://www.maib.gov.uk/#{$1}")
+        end
+
+      when 'www.raib.gov.uk', 'raib.gov.uk'
+        case request.non_canonicalised_fullpath
+        when %r{^/sites/raib/(.*)$}i
+          redirect("http://www.raib.gov.uk/#{$1}")
+        end
+
       when 'www.businesslink.gov.uk', 'businesslink.gov.uk'
         case request.non_canonicalised_fullpath
         when %r{^(.*site=230.*)$}i

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -1063,6 +1063,41 @@ describe 'HTTP request handling' do
 
     end
 
+    describe 'Accident Investigation Branches multi-surfaced content' do
+      before { site.hosts.create hostname: 'www.aaib.gov.uk' }
+      before { site.hosts.create hostname: 'www.maib.gov.uk' }
+      before { site.hosts.create hostname: 'www.raib.gov.uk' }
+
+      describe 'visiting an AAIB multi surfaced page' do
+        before do
+          get 'http://www.aaib.gov.uk/sites/aaib/publications/bulletins/january_2006/pierre_robin_dr400_180__g_bsla.htm'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.aaib.gov.uk/publications/bulletins/january_2006/pierre_robin_dr400_180__g_bsla.htm' }
+      end
+
+      describe 'visiting a RAIB multi surfaced page' do
+        before do
+          get 'http://www.raib.gov.uk/sites/raib/publications/index.cfm'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.raib.gov.uk/publications/index.cfm' }
+      end
+
+      describe 'visiting a MAIB multi surfaced page' do
+        before do
+          get 'http://www.maib.gov.uk/sites/maib/home/index.cfm'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.maib.gov.uk/home/index.cfm' }
+      end
+
+    end
+
+
     describe 'Treasury redirects' do
       before { site.hosts.create hostname: 'cdn.hm-treasury.gov.uk' }
 


### PR DESCRIPTION
These rules handle multisurfaced AAIB MAIB and RAIB content.

They are not designed to handle the scenario like www.aaib.gov.uk/sites/raib/whatever, that can be handled under separate cover, should we decide that a 404 is not appropriate. 

For clarity, these three sites surface pages in two separate urlspaces. Content at ```/sites/aaib/foo/bar``` equals content at ```/foo/bar```