### PR TITLE
Add *.nhs.uk as an automatically allowed ending for a hostname

### DIFF
--- a/lib/bouncer/outcome/base.rb
+++ b/lib/bouncer/outcome/base.rb
@@ -16,7 +16,7 @@ module Bouncer
 
       def legal_redirect?(url)
         host = Addressable::URI.parse(url).host
-        host.end_with?('.gov.uk') || host.end_with?('.mod.uk') || WhitelistedHost.exists?(hostname: host)
+        host.end_with?('.gov.uk') || host.end_with?('.mod.uk') || host.end_with?('.nhs.uk') || WhitelistedHost.exists?(hostname: host)
       end
     end
   end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -208,6 +208,20 @@ describe 'HTTP request handling' do
     its(:location) { should == 'http://anything-at-all.mod.uk' }
   end
 
+  describe 'visiting a URL which redirects to anything on *.nhs.uk' do
+    before do
+      site.mappings.create \
+        path:          '/a-redirected-page',
+        type:          'redirect',
+        new_url:       'http://anything-at-all.nhs.uk'
+
+      get 'https://www.minitrue.gov.uk/a-redirected-page'
+    end
+
+    its(:status) { should == 301 }
+    its(:location) { should == 'http://anything-at-all.nhs.uk' }
+  end
+
   describe 'visiting a URL which redirects to a URL including square brackets' do
     before do
       site.mappings.create \


### PR DESCRIPTION
- The corresponding Transition Tool change is
  https://github.com/alphagov/transition/pull/485 - see there for
  context.