### PR TITLE
Add rule for planning-portal session-variant homepage

### DIFF
--- a/lib/bouncer/preemptive_rules.rb
+++ b/lib/bouncer/preemptive_rules.rb
@@ -68,6 +68,12 @@ module Bouncer
         when %r{^/(.*)$}
           redirect("http://www.dft.gov.uk/mca/#{$1}")
         end
+
+      when 'www.planningportal.gov.uk', 'planningportal.gov.uk'
+        case request.non_canonicalised_fullpath
+        when %r{^/wps/portal/portalhome/unauthenticatedhome/!ut/}
+          redirect("http://www.planningportal.gov.uk")
+        end
       end
 
     end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -987,6 +987,32 @@ describe 'HTTP request handling' do
       end
     end
 
+    describe 'Planning Portal redirects' do
+      before { site.hosts.create hostname: 'www.planningportal.gov.uk' }
+
+      describe 'session based unauthenticated home page' do
+        before do
+          get 'http://www.planningportal.gov.uk/wps/portal/portalhome/unauthenticatedhome/!ut/p/c5/04_SB8K8xLLM9MSSzPy8xBz9CP0os3gjtxBnJydDRwMLbzdLA09nSw_zsKBAIwN3U_1wkA6zeHMXS4gKd29TRwNPI0s3b2e_AGMDAwOIvAEO4Gig7-eRn5uqX5CdneboqKgIAGUwqho!/dl3/d3/L2dBISEvZ0FBIS9nQSEh/'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.planningportal.gov.uk' }
+      end
+    end
+
+    describe 'Planning Portal non-www redirects' do
+      before { site.hosts.create hostname: 'planningportal.gov.uk' }
+
+      describe 'session based unauthenticated home page' do
+        before do
+          get 'http://planningportal.gov.uk/wps/portal/portalhome/unauthenticatedhome/!ut/p/c5/04_SB8K8xLLM9MSSzPy8xBz9CP0os3gjtxBnJydDRwMLbzdLA09nSw_zsKBAIwN3U_1wkA6zeHMXS4gKd29TRwNPI0s3b2e_AGMDAwOIvAEO4Gig7-eRn5uqX5CdneboqKgIAGUwqho!/dl3/d3/L2dBISEvZ0FBIS9nQSEh/'
+        end
+
+        it_behaves_like 'a 301'
+        its(:location) { should == 'http://www.planningportal.gov.uk' }
+      end
+    end
+
     describe 'Number 10 redirects' do
       before { site.hosts.create hostname: 'www.number10.gov.uk' }
 


### PR DESCRIPTION
The homepage of www.planningportal.gov.uk redirects to a
session-based URL ([example](http://www.planningportal.gov.uk/wps/portal/portalhome/unauthenticatedhome/!ut/p/c5/04_SB8K8xLLM9MSSzPy8xBz9CP0os3gjtxBnJydDRwMLbzdLA09nSw_zsKBAIwN3U_1wkA6zeHMXS4gKd29TRwNPI0s3b2e_AGMDAwOIvAEO4Gig7-eRn5uqX5CdneboqKgIAGUwqho!/dl3/d3/L2dBISEvZ0FBIS9nQSEh/.)) We found ~18,000 of these URLs while
building a list of URLs for the site, and users may well have
bookmarked them, so we should redirect them.

This adds pre-emptive redirect that points to the homepage, which
will then redirect to whatever we map `/` to, which will avoid
having to duplicate that redirect destination..