### PR TITLE
Twelve-factorise PostgreSQL connection

### DIFF
--- a/boot.rb
+++ b/boot.rb
@@ -1,6 +1,10 @@
 require 'active_record'
 RACK_ENV ||= ENV['RACK_ENV'] || 'development'
-ActiveRecord::Base.establish_connection(YAML.load(File.read(File.expand_path('../config/database.yml', __FILE__)))[RACK_ENV])
+
+if ENV['DATABASE_URL'].exists?
+  ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+else
+  ActiveRecord::Base.establish_connect(YAML.load(File.read(File.expand_path('../config/database.yml', __FILE__)))[RACK_ENV])
 
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 


### PR DESCRIPTION
In order to twelve-factorise Bouncer, we should use DATABASE_URL so that the
database to establish a connection to can be sent by environment variables.
Set a fall-back mechanism to read from the YAML file copied during
deployment if no DATABASE_URL environment variable exists.