### PR TITLE
Canary route

### DIFF
--- a/lib/bouncer.rb
+++ b/lib/bouncer.rb
@@ -16,6 +16,7 @@ require 'bouncer/fallback_rules'
 require 'bouncer/preemptive_rules'
 
 require 'bouncer/outcome/base'
+require 'bouncer/outcome/canary'
 require 'bouncer/outcome/global_type'
 require 'bouncer/outcome/healthcheck'
 require 'bouncer/outcome/unrecognised_host'

--- a/lib/bouncer/app.rb
+++ b/lib/bouncer/app.rb
@@ -14,7 +14,7 @@ module Bouncer
                   Outcome::UnrecognisedHost
                 when ['/404', '/410'].include?(context.request.path)
                   Outcome::TestThe4xxPages
-                when context.host == 'www.direct.gov.uk' && context.request.path == '__canary__'
+                when context.host.hostname == 'www.direct.gov.uk' && context.request.path == '/__canary__'
                   Outcome::Canary
                 when context.request.path == '/sitemap.xml'
                   Outcome::Sitemap

--- a/lib/bouncer/app.rb
+++ b/lib/bouncer/app.rb
@@ -14,6 +14,8 @@ module Bouncer
                   Outcome::UnrecognisedHost
                 when ['/404', '/410'].include?(context.request.path)
                   Outcome::TestThe4xxPages
+                when context.host == 'www.direct.gov.uk' && context.request.path == '__canary__'
+                  Outcome::Canary
                 when context.request.path == '/sitemap.xml'
                   Outcome::Sitemap
                 when context.request.path == '/robots.txt'

--- a/lib/bouncer/cacher.rb
+++ b/lib/bouncer/cacher.rb
@@ -8,6 +8,8 @@ module Bouncer
 
     def call(env)
       @app.call(env).tap do |status, headers|
+        # Double pipe equals (||=) assigns a value to a variable
+        # only when that variable is nil or false.
         headers['Cache-Control'] ||= 'public, max-age=3600' unless status == 500
       end
     end

--- a/lib/bouncer/outcome/canary.rb
+++ b/lib/bouncer/outcome/canary.rb
@@ -3,8 +3,7 @@ module Bouncer
     class Canary < Base
       HEADERS = {
         'Content-Type' => 'text/plain',
-        # FIXME: stop this being overridden by our cacher middleware:
-        'Cache-Control' => 'private'
+        'Cache-Control' => 'private',
       }
 
       def serve

--- a/lib/bouncer/outcome/canary.rb
+++ b/lib/bouncer/outcome/canary.rb
@@ -8,22 +8,36 @@ module Bouncer
       }
 
       def serve
-        if can_select_from_required_tables?
+        if is_alive?
           [200, HEADERS, ['OK: The canary is alive']]
         else
-          [500, HEADERS, ['Internal Server Error']]
+          [503, HEADERS, ['Service Unavailable']]
         end
       end
 
-      def can_select_from_required_tables?
-        # At this point we've already SELECTed from the hosts table.
+    private
+      def is_alive?
+        # We want to make sure we can select from each of these tables
+        # and that each of these tables returns something.
 
-        # Check that Bouncer can SELECT from the sites and mappings tables:
-        test_mapping = context.mappings.where(type: 'redirect').first
+        begin
+          # At this point we've already SELECTed from the hosts table.
 
-        # Check that Bouncer can SELECT from the organisations and
-        # whitelisted_hosts tables:
-        organisation && test_mapping && legal_redirect?(test_mapping.new_url)
+          # Check for the site
+          test_site = context.site
+
+          # Check that Bouncer can SELECT from the mappings table:
+          test_mapping = context.mappings.first
+
+          # Check that there is a WhitelistedHost
+          test_whitelisted_host = WhitelistedHost.first
+
+          # Check that Bouncer can SELECT from the organisations table
+          # and test that the results of the previous 2 queries are not nil
+          test_site && context.organisation && test_mapping && test_whitelisted_host
+        rescue
+          false
+        end
       end
     end
   end

--- a/lib/bouncer/outcome/canary.rb
+++ b/lib/bouncer/outcome/canary.rb
@@ -1,0 +1,30 @@
+module Bouncer
+  module Outcome
+    class Canary < Base
+      HEADERS = {
+        'Content-Type' => 'text/plain',
+        # FIXME: stop this being overridden by our cacher middleware:
+        'Cache-Control' => 'private'
+      }
+
+      def serve
+        if can_select_from_required_tables?
+          [200, HEADERS, ['OK: The canary is alive']]
+        else
+          [500, HEADERS, ['Internal Server Error']]
+        end
+      end
+
+      def can_select_from_required_tables?
+        # At this point we've already SELECTed from the hosts table.
+
+        # Check that Bouncer can SELECT from the sites and mappings tables:
+        test_mapping = context.mappings.where(type: 'redirect').first
+
+        # Check that Bouncer can SELECT from the organisations and
+        # whitelisted_hosts tables:
+        organisation && test_mapping && legal_redirect?(test_mapping.new_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If Bouncer goes down outside normal working hours, the people on call should be notified. The app and the check should also be documented in the opsmanual so that they are able to take appropriate action if necessary.

This PR adds a canary route at `/__canary__` which checks to see if it can select from 3 of the tables. If any of these 3 checks throw an error or can't connect, we return a `503`. [Ticket](https://trello.com/c/FrsSm5oK/69-alert-out-of-hours-if-bouncer-is-down).

Original work done by @jennyd. Props to her for starting and helping me with this. ✊✊✊✊✊