### PR TITLE
Upgrade activerecord and nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org/'
 
-gem 'activerecord', '4.1.11' # Ideally version should be synced with Transition
+gem 'activerecord', '4.1.14.1' # Ideally version should be synced with Transition
 gem 'pg', '0.17.1'
-gem 'nokogiri', '1.6.0'
+gem 'nokogiri', '1.6.7.2'
 gem 'rack', '1.5.4'
 gem 'optic14n', '2.0.0' # Ideally version should be synced with Transition
 gem 'erubis', '2.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.1.11)
-      activesupport (= 4.1.11)
+    activemodel (4.1.14.1)
+      activesupport (= 4.1.14.1)
       builder (~> 3.1)
-    activerecord (4.1.11)
-      activemodel (= 4.1.11)
-      activesupport (= 4.1.11)
+    activerecord (4.1.14.1)
+      activemodel (= 4.1.14.1)
+      activesupport (= 4.1.14.1)
       arel (~> 5.0.0)
-    activesupport (4.1.11)
+    activesupport (4.1.14.1)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -19,7 +19,7 @@ GEM
       builder
       multi_json
     arel (5.0.1.20140414130214)
-    builder (3.1.4)
+    builder (3.2.2)
     database_cleaner (1.0.1)
     diff-lcs (1.2.4)
     erubis (2.7.0)
@@ -31,16 +31,16 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
-    mini_portile (0.5.0)
-    minitest (5.7.0)
+    mini_portile2 (2.0.0)
+    minitest (5.8.4)
     mr-sparkle (0.2.0)
       listen (~> 1.0)
       rb-fsevent (>= 0.9)
       rb-inotify (>= 0.8)
       unicorn (>= 4.5)
     multi_json (1.8.2)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     optic14n (2.0.0)
       addressable (~> 2.3)
     pg (0.17.1)
@@ -74,12 +74,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (= 4.1.11)
+  activerecord (= 4.1.14.1)
   airbrake (= 3.1.15)
   database_cleaner (= 1.0.1)
   erubis (= 2.7.0)
   mr-sparkle (= 0.2.0)
-  nokogiri (= 1.6.0)
+  nokogiri (= 1.6.7.2)
   optic14n (= 2.0.0)
   pg (= 0.17.1)
   rack (= 1.5.4)
@@ -87,3 +87,6 @@ DEPENDENCIES
   rake (= 10.1.0)
   rspec (= 2.13.0)
   unicorn (= 4.6.3)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
ActiveRecord: 4.1.11 -> 4.1.14.1 which covers CVE-2015-7577 and
CVE-2016-0753
Nokogiri: 1.6.0 -> 1.6.7.2 which covers CVE-2015-7499, CVE-2015-5312,
CVE-2015-7497, CVE-2015-7498, CVE-2015-7499, CVE-2015-7500, CVE-2015-8241,
CVE-2015-8242, CVE-2015-8317, CVE-2015-1819, CVE-2015-7941_1,
CVE-2015-7941_2, CVE-2015-7942, CVE-2015-7942-2, CVE-2015-8035,
CVE-2015-7995, CVE-2013-2877, and CVE-2014-0191 (mostly libxml).