### PR TITLE
Add fallback rules for Land Registry house prices site

### DIFF
--- a/lib/bouncer/fallback_rules.rb
+++ b/lib/bouncer/fallback_rules.rb
@@ -39,6 +39,13 @@ module Bouncer
         else
           redirect('https://www.gov.uk/digital-marketplace')
         end
+      when 'houseprices.landregistry.gov.uk', 'www.houseprices.landregistry.gov.uk'
+        case request.path
+        when %r{^/sold-prices/.*}
+          redirect('http://landregistry.data.gov.uk/app/ppd')
+        when %r{^/price-paid-record/.*}
+          redirect('http://landregistry.data.gov.uk/app/ppd')
+        end
       end
     end
   end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -1728,6 +1728,36 @@ describe 'HTTP request handling' do
       end
     end
 
+    describe 'Land Registry house prices redirects' do
+      before { site.hosts.create hostname: 'houseprices.landregistry.gov.uk' }
+
+      describe 'visiting a /sold-prices/* URL' do
+        before do
+          get 'http://houseprices.landregistry.gov.uk/sold-prices/WC2B6NH'
+        end
+
+        it_behaves_like 'a 301'
+
+        describe '#location' do
+          subject { super().location }
+          it { is_expected.to eq('http://landregistry.data.gov.uk/app/ppd') }
+        end
+      end
+
+      describe 'visiting a /price-paid-record/* URL' do
+        before do
+          get 'http://houseprices.landregistry.gov.uk/price-paid-record/1234567/125+kingsway+london'
+        end
+
+        it_behaves_like 'a 301'
+
+        describe '#location' do
+          subject { super().location }
+          it { is_expected.to eq('http://landregistry.data.gov.uk/app/ppd') }
+        end
+      end
+    end
+
     describe 'visiting www.direct.gov.uk/__canary__' do
 
       before do


### PR DESCRIPTION
These paths contain address and postcode search parameters, so can't be
mapped.

These rules don't preserve the search - they just redirect to the new price
paid dataset search page. Land Registry have confirmed that this is the right
URL to redirect to.

This rule could be a one-liner, but I thought it was clearer as a `case`:

```ruby
redirect('http://landregistry.data.gov.uk/app/ppd') if request.path =~ %r{(^/sold-prices)|(^/price-paid-record)}
```

This should fix the vast majority of [the 404s Bouncer is serving right now](https://kibana.publishing.service.gov.uk/kibana#/dashboard/elasticsearch/Bouncer).