### PR TITLE
Read Airbrake config from environment

### DIFF
--- a/config/airbrake.rb
+++ b/config/airbrake.rb
@@ -1,5 +1,8 @@
-# Overwritten at deploy-time
 require 'airbrake'
 
 Airbrake.configure do |config|
+  config.api_key = ENV['ERRBIT_API_KEY']
+  config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
+  config.secure = true
+  config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
 end


### PR DESCRIPTION
For the time being this file will still be overwritten at deploy time, but once we remove that functionality from govuk-app-deployment this new file will start to be used.