### PR TITLE
Bump Optic14n to stay in step with Transition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'activerecord', '4.2.6' # Ideally version should be synced with Transition
 gem 'pg', '0.18.4'
 gem 'nokogiri', '1.6.7.2'
 gem 'rack', '1.6.4'
-gem 'optic14n', '2.0.0' # Ideally version should be synced with Transition
+gem 'optic14n', '2.0.1' # Ideally version should be synced with Transition
 gem 'erubis', '2.7.0'
 gem 'airbrake', '~> 4.3.0'
 gem 'rake', '10.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
+    addressable (2.4.0)
     airbrake (4.3.6)
       builder
       multi_json
@@ -41,7 +41,7 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
-    optic14n (2.0.0)
+    optic14n (2.0.1)
       addressable (~> 2.3)
     pg (0.18.4)
     rack (1.6.4)
@@ -85,7 +85,7 @@ DEPENDENCIES
   erubis (= 2.7.0)
   mr-sparkle (= 0.3.0)
   nokogiri (= 1.6.7.2)
-  optic14n (= 2.0.0)
+  optic14n (= 2.0.1)
   pg (= 0.18.4)
   rack (= 1.6.4)
   rack-test (= 0.6.3)
@@ -94,4 +94,4 @@ DEPENDENCIES
   unicorn (~> 5.0.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
We've fixed a bug in Optic14n to resolve this error in Transition:

To fix https://errbit.publishing.service.gov.uk/apps/530f56010da115868600173d/problems/577c047a65786352db2b0400

This error occurs when canonicalizing query strings.  It appears that not every
character emerges unscathed from this process.  In this case, having `%E2`
(which is equivalent to "â")  in a key of a query string results in the error
found in Errbit.

We need to keep Bouncer and Transition in step so they can use the same
canonicalization code.

See https://trello.com/c/ihTQRRMX/325-encoding-error-on-hits-import-in-transition
 for further explanation and context.