### PR TITLE
Upgrade Active Record to 4.2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org/'
 
-gem 'activerecord', '4.2.6' # Ideally version should be synced with Transition
+gem 'activerecord', '4.2.7.1' # Ideally version should be synced with Transition
 gem 'pg', '0.18.4'
 gem 'nokogiri', '1.6.7.2'
 gem 'rack', '1.6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.6)
-      activesupport (= 4.2.6)
+    activemodel (4.2.7.1)
+      activesupport (= 4.2.7.1)
       builder (~> 3.1)
-    activerecord (4.2.6)
-      activemodel (= 4.2.6)
-      activesupport (= 4.2.6)
+    activerecord (4.2.7.1)
+      activemodel (= 4.2.7.1)
+      activesupport (= 4.2.7.1)
       arel (~> 6.0)
-    activesupport (4.2.6)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -32,7 +32,7 @@ GEM
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     mr-sparkle (0.3.0)
       listen (~> 1.0)
       rb-fsevent (>= 0.9)
@@ -79,7 +79,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (= 4.2.6)
+  activerecord (= 4.2.7.1)
   airbrake (~> 4.3.0)
   database_cleaner (= 1.5.1)
   erubis (= 2.7.0)


### PR DESCRIPTION
This is necessary due to an unsafe query generation risk in Active Record

Advisory: CVE-2016-6317
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/rgO20zYW33s

A PR to keep Transition in sync will also be raised ( https://github.com/alphagov/transition/pull/521 )