### PR TITLE
Add aliases to fallback rule for number10 news

### DIFF
--- a/lib/bouncer/fallback_rules.rb
+++ b/lib/bouncer/fallback_rules.rb
@@ -25,7 +25,7 @@ module Bouncer
         redirect('https://www.gov.uk/search') if request.path =~ %r{/(en/)?AdvancedSearch}i
       when 'campaigns.direct.gov.uk'
         redirect('https://www.gov.uk/firekills') if request.path =~ %r{/firekills}
-      when 'www.number10.gov.uk', 'number10.gov.uk'
+      when 'www.number10.gov.uk', 'number10.gov.uk', 'www.pm.gov.uk', 'pm.gov.uk', 'www.number-10.gov.uk', 'number-10.gov.uk'
         redirect("http://www.number10.gov.uk/news/#{$4}") if
           request.path =~ %r{^/news/?([_0-9a-zA-Z-]+)?/([0-9]+)/([0-9]+)/(.*)-([0-9]+)$}
       when 'cdn.hm-treasury.gov.uk'


### PR DESCRIPTION
We're [adding these domains as aliases of the site](https://github.com/alphagov/transition-config/pull/1201), so need to add them here as
well for the rule to apply to them. number10.gov.uk was already here despite
not being in transition-config.