### PR TITLE
Update db/structure.sql from Transition

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -255,8 +255,9 @@ CREATE TABLE mappings_batch_entries (
     mapping_id integer,
     processed boolean DEFAULT false,
     klass character varying(255) DEFAULT NULL::character varying,
-    new_url character varying(2048) DEFAULT NULL::character varying,
-    type character varying(255) DEFAULT NULL::character varying
+    new_url text DEFAULT NULL::character varying,
+    type character varying(255) DEFAULT NULL::character varying,
+    archive_url text
 );
 
 
@@ -1159,6 +1160,13 @@ CREATE UNIQUE INDEX index_sites_on_site ON sites USING btree (abbr);
 
 
 --
+-- Name: index_taggings_on_taggable_id_and_taggable_type_and_context; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_taggings_on_taggable_id_and_taggable_type_and_context ON taggings USING btree (taggable_id, taggable_type, context);
+
+
+--
 -- Name: index_taggings_on_taggable_type_and_taggable_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1371,5 +1379,13 @@ INSERT INTO schema_migrations (version) VALUES ('20150423102347');
 INSERT INTO schema_migrations (version) VALUES ('20150428155430');
 
 INSERT INTO schema_migrations (version) VALUES ('20150429154045');
+
+INSERT INTO schema_migrations (version) VALUES ('20150715141152');
+
+INSERT INTO schema_migrations (version) VALUES ('20160314150052');
+
+INSERT INTO schema_migrations (version) VALUES ('20160314150053');
+
+INSERT INTO schema_migrations (version) VALUES ('20161111172455');
 
 


### PR DESCRIPTION
Bouncer and Transition share a database, so we should keep the `structure.sql` here up to date when we modify the database schema in Transition. It looks like we haven't done this for a while, so there are a few changes, although none which affect tables used by Bouncer.

Generated with `rake db:structure:dump` in Transition and copied over.

https://trello.com/c/MGtcYgQV/549-fix-limit-on-archive-url-length-when-importing-batches-in-transition