### PR TITLE
Use Sentry for error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'nokogiri', '1.6.7.2'
 gem 'rack', '~> 2.0.1'
 gem 'optic14n', '2.0.1' # Ideally version should be synced with Transition
 gem 'erubis', '2.7.0'
-gem 'airbrake', '~> 4.3.0'
+gem 'govuk_app_config', '~> 0.2'
 gem 'rake', '10.1.0'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,17 +13,18 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    airbrake (4.3.6)
-      builder
-      multi_json
     arel (8.0.0)
-    builder (3.2.3)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     database_cleaner (1.5.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
+    govuk_app_config (0.2.0)
+      sentry-raven (~> 2.6.3)
+      statsd-ruby (~> 1.4.0)
     i18n (0.8.4)
     kgio (2.10.0)
     listen (1.3.1)
@@ -38,7 +39,7 @@ GEM
       rb-fsevent (>= 0.9)
       rb-inotify (>= 0.8)
       unicorn (>= 4.5)
-    multi_json (1.11.2)
+    multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     optic14n (2.0.1)
@@ -71,7 +72,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    sentry-raven (2.6.3)
+      faraday (>= 0.7.6, < 1.0)
     slop (3.6.0)
+    statsd-ruby (1.4.0)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -85,9 +89,9 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.1.1)
-  airbrake (~> 4.3.0)
   database_cleaner (= 1.5.1)
   erubis (= 2.7.0)
+  govuk_app_config (~> 0.2)
   mr-sparkle (= 0.3.0)
   nokogiri (= 1.6.7.2)
   optic14n (= 2.0.1)
@@ -100,4 +104,4 @@ DEPENDENCIES
   unicorn (~> 5.0.0)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
-require 'airbrake'
-require 'airbrake_tasks'
+require 'govuk_app_config'
 
 if ENV['RACK_ENV'] != "production"
   require 'rspec/core/rake_task'
@@ -12,19 +11,5 @@ namespace :db do
     sh "dropdb --if-exists transition_test"
     sh "createdb --encoding=UTF8 --template=template0 transition_test"
     sh "cat db/structure.sql | psql -d transition_test"
-  end
-end
-
-namespace :errbit do
-  desc 'Notify Errbit of a deploy'
-  task :deploy do
-    require './config/airbrake'
-
-    # This should use Airbrake.configuration, including the API key
-    AirbrakeTasks.deploy(:rails_env      => ENV['TO'],
-                         :scm_revision   => ENV['REVISION'],
-                         :scm_repository => ENV['REPO'],
-                         :local_username => ENV['USER'],
-                         :dry_run        => ENV['DRY_RUN'])
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -2,11 +2,7 @@ require './boot'
 require 'rack/static'
 require './lib/active_record/rack/connection_management'
 
-if ENV['RACK_ENV'] == 'production'
-  require './config/airbrake'
-  use Airbrake::Rack
-end
-
+use Raven::Rack
 use Bouncer::Cacher
 
 # We need compatibility with redirector which serves its assets from '/''.

--- a/config/airbrake.rb
+++ b/config/airbrake.rb
@@ -1,8 +1,0 @@
-require 'airbrake'
-
-Airbrake.configure do |config|
-  config.api_key = ENV['ERRBIT_API_KEY']
-  config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
-  config.secure = true
-  config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
-end

--- a/lib/bouncer.rb
+++ b/lib/bouncer.rb
@@ -7,7 +7,7 @@ require 'status_renderer'
 require 'host'
 require 'whitelisted_host'
 require 'optic14n'
-require 'airbrake'
+require 'govuk_app_config'
 
 require 'bouncer/cacher'
 require 'bouncer/canonicalized_request'


### PR DESCRIPTION
This commit makes the app use Sentry for error reporting.

- Remove Airbrake gem & config
- Add [govuk_app_config][] which adds the Sentry gem ([sentry-raven][])

[govuk_app_config]: https://github.com/alphagov/govuk_app_config
[sentry-raven]: https://github.com/getsentry/raven-ruby

https://trello.com/c/smPvoz8w