### PR TITLE
Stop reporting PG::ConnectionBad

### DIFF
--- a/lib/bouncer.rb
+++ b/lib/bouncer.rb
@@ -9,6 +9,7 @@ require 'whitelisted_host'
 require 'optic14n'
 require 'govuk_app_config'
 
+require 'bouncer/error_reporting'
 require 'bouncer/cacher'
 require 'bouncer/canonicalized_request'
 require 'bouncer/request_context'

--- a/lib/bouncer/error_reporting.rb
+++ b/lib/bouncer/error_reporting.rb
@@ -1,0 +1,5 @@
+Raven.configure do |config|
+  # In staging and integration we often see tens of thousands `PG::ConnectionBad`
+  # errors a day during data syncs. This is eating up our Sentry quota.
+  config.excluded_exceptions << "PG::ConnectionBad"
+end


### PR DESCRIPTION
We've already seen 130K `PG::ConnectionBad` errors reported to Sentry:

https://sentry.io/govuk/app-bouncer/issues/335728174

This should filter out the errors per https://docs.sentry.io/clients/ruby/config/

I've tried to solve this by upping the connection limit on the transition postgres machines in https://github.com/alphagov/govuk-puppet/pull/6448, but that didn't seem to have helped. I suspect that it's an application issue, perhaps related to the upgrade in https://github.com/alphagov/bouncer/commit/91b6c7b3cc25af9eb18826d144a406af4bec9830.

I've created a ticket for a longer term solution: 

https://trello.com/c/NSVAgy9D/170-fix-database-errors-in-bouncer
