### PR TITLE
Remove unicorn gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,6 @@ gem 'erubis', '2.7.0'
 gem 'govuk_app_config', '~> 0.2'
 gem 'rake', '12.3.0'
 
-group :production do
-  gem 'unicorn', '~> 5.3.1'
-end
-
 group :development do
   gem 'mr-sparkle', '0.3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,6 @@ DEPENDENCIES
   rack-test (= 0.8.2)
   rake (= 12.3.0)
   rspec (~> 3.7.0)
-  unicorn (~> 5.3.1)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0


### PR DESCRIPTION
This is now included as a dependency in govuk_app_config.

To be merged after https://github.com/alphagov/bouncer/pull/156