### PR TITLE
Add support for remote Docker database

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'govuk_app_config'
+require 'uri'
 
 if ENV['RACK_ENV'] != "production"
   require 'rspec/core/rake_task'
@@ -8,8 +9,14 @@ end
 
 namespace :db do
   task :reset do
-    sh "dropdb --if-exists transition_test"
-    sh "createdb --encoding=UTF8 --template=template0 transition_test"
-    sh "cat db/structure.sql | psql -d transition_test"
+    if ENV["TEST_DATABASE_URL"]
+      uri = URI.parse(ENV["TEST_DATABASE_URL"])
+      host = "-h #{uri.host}"
+      user = "-U #{uri.user}"
+    end
+
+    sh "dropdb #{host} #{user} --if-exists transition_test"
+    sh "createdb #{host} #{user} --encoding=UTF8 --template=template0 transition_test"
+    sh "cat db/structure.sql | psql #{host} #{user} -d transition_test"
   end
 end

--- a/boot.rb
+++ b/boot.rb
@@ -4,7 +4,7 @@ RACK_ENV ||= ENV['RACK_ENV'] || 'development'
 if ENV['DATABASE_URL']
   ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
 else
-  ActiveRecord::Base.establish_connection(YAML.load(File.read(File.expand_path('../config/database.yml', __FILE__)))[RACK_ENV])
+  ActiveRecord::Base.establish_connection(YAML.load(ERB.new(File.read(File.expand_path('../config/database.yml', __FILE__))).result)[RACK_ENV])
 end
 
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,7 @@
 development:
   adapter: postgresql
   database: transition_development
+  url: <%= ENV["DATABASE_URL"]%>
 
 # Warning: The contents of the database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -8,6 +9,7 @@ development:
 test:
   adapter: postgresql
   database: transition_test
+  url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
   adapter: postgresql


### PR DESCRIPTION
Unfortunately it appears to be quite hard to invoke ActiveRecord
DB tasks outside of the Rails framework [1].

[1]: https://jer-k.github.io/add-active-record-rake-tasks-to-gem/