### PR TITLE
Improve healthcheck using govuk_app_config

### DIFF
--- a/lib/bouncer/app.rb
+++ b/lib/bouncer/app.rb
@@ -7,7 +7,7 @@ module Bouncer
     def call(env)
       context = RequestContext.new(CanonicalizedRequest.new(env))
 
-      outcome = if context.host.nil? && context.request.path == "/healthcheck"
+      outcome = if context.request.path == "/healthcheck"
                   Outcome::Healthcheck
                 elsif context.host.nil?
                   Outcome::UnrecognisedHost

--- a/lib/bouncer/outcome/healthcheck.rb
+++ b/lib/bouncer/outcome/healthcheck.rb
@@ -2,7 +2,9 @@ module Bouncer
   module Outcome
     class Healthcheck < Base
       def serve
-        [200, { "Content-Type" => "text/plain" }, %w[OK]]
+        GovukHealthcheck.rack_response(
+          GovukHealthcheck::ActiveRecord,
+        ).call
       end
     end
   end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -871,9 +871,9 @@ describe "HTTP request handling" do
       it_behaves_like "a 200"
 
       describe "#body" do
-        subject { super().body }
+        subject { JSON.parse(super().body) }
 
-        it { is_expected.to match %r{^OK$} }
+        it { is_expected.to have_key("status") }
       end
     end
   end


### PR DESCRIPTION
This ensures that the app is able to connect to ActiveRecord.
This is a precursor to enabling CD on Bouncer.

Trello: https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps