### PR TITLE
Handle invalid hosts gracefully

### DIFF
--- a/lib/bouncer.rb
+++ b/lib/bouncer.rb
@@ -17,6 +17,7 @@ require "bouncer/fallback_rules"
 require "bouncer/preemptive_rules"
 
 require "bouncer/outcome/base"
+require "bouncer/outcome/bad_request"
 require "bouncer/outcome/canary"
 require "bouncer/outcome/global_type"
 require "bouncer/outcome/healthcheck"

--- a/lib/bouncer/app.rb
+++ b/lib/bouncer/app.rb
@@ -11,6 +11,8 @@ module Bouncer
                   Outcome::Healthcheck
                 elsif context.host.nil?
                   Outcome::UnrecognisedHost
+                elsif !context.valid?
+                  Outcome::BadRequest
                 elsif ["/404", "/410"].include?(context.request.path)
                   Outcome::TestThe4xxPages
                 elsif context.host.hostname == "www.direct.gov.uk" && context.request.path == "/__canary__"

--- a/lib/bouncer/canonicalized_request.rb
+++ b/lib/bouncer/canonicalized_request.rb
@@ -4,6 +4,13 @@ module Bouncer
       @request = Rack::Request.new(env_or_request)
     end
 
+    def valid?
+      bluri
+      true
+    rescue Addressable::URI::InvalidURIError
+      false
+    end
+
     def non_canonicalised_fullpath
       @request.fullpath
     end

--- a/lib/bouncer/outcome/bad_request.rb
+++ b/lib/bouncer/outcome/bad_request.rb
@@ -1,0 +1,9 @@
+module Bouncer
+  module Outcome
+    class BadRequest < Base
+      def serve
+        [400, {}, ["Bad Request"]]
+      end
+    end
+  end
+end

--- a/lib/bouncer/request_context.rb
+++ b/lib/bouncer/request_context.rb
@@ -9,6 +9,10 @@ module Bouncer
       @request = canonicalized_request
     end
 
+    def valid?
+      @request.valid?
+    end
+
     def host
       @host ||= Host.find_by(hostname: @request.host)
     end

--- a/spec/units/bouncer/app_spec.rb
+++ b/spec/units/bouncer/app_spec.rb
@@ -292,4 +292,19 @@ describe Bouncer::App do
       expect(last_response).to be_not_found
     end
   end
+
+  context "when the host is malformed" do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Bouncer::RequestContext).to receive(:valid?).and_return(false)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    let(:host) { double("host").as_null_object } # value unimportant, but needed for `url` to resolve
+
+    it "responds with the correct status code" do
+      get url
+      expect(last_response.status).to eq(400)
+    end
+  end
 end

--- a/spec/units/bouncer/canonicalized_request_spec.rb
+++ b/spec/units/bouncer/canonicalized_request_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe Bouncer::CanonicalizedRequest do
+  include Rack::Test::Methods
+
+  describe "valid?" do
+    let(:env) { "foo" }
+
+    it "returns true if valid URI passed" do
+      canonicalized_request = described_class.new(env)
+      allow(canonicalized_request).to receive(:bluri).and_return(instance_double("Rack::Request"))
+      expect(canonicalized_request.valid?).to be(true)
+    end
+
+    it "returns false if invalid URI passed" do
+      canonicalized_request = described_class.new(env)
+      allow(canonicalized_request).to receive(:bluri).and_raise(Addressable::URI::InvalidURIError)
+      expect(canonicalized_request.valid?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
We're seeing fairly high volumes of errors in Sentry:
https://sentry.io/organizations/govuk/issues/2086648123/events/80d68b1848f24f7b82e08cb839b64dc2/?project=202210

These errors happen when an invalid (malformed) host is passed to
Bouncer, leading to a `Addressable::URI::InvalidURIError` being
raised. We see an error message of the form:
`Invalid character in host: 'foo.gov.uk))'("),,)'`

We can't stop those requests from being made, but we can avoid
logging inactionable errors in Sentry. This change detects the
`Addressable::URI::InvalidURIError` exception and returns a 400
Bad Request error gracefully: https://httpstatuses.com/400

It wasn't straightforward to add a test for this, as any attempt
to `get url` (where `url` is malformed as above) would break at
the RSpec level and not reach our application code. Consequently,
I've had to do some slightly smelly mocking.

The biggest smell is probably the `allow_any_instance_of`, which
is a pragmatic choice that is better than the alternative (moving
the `context` assignment in `Bouncer::App` into its own method and
stubbing that instead). We'd have had to either make calls to the
`context` method throughout the `call` (inefficient) or cache it
with `@context ||=` (could cause bugs). A slightly non-standard
test feels like the least risky approach here.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
