### PR TITLE
Return `Outcome::BadRequest` early if bad request

### DIFF
--- a/lib/bouncer/app.rb
+++ b/lib/bouncer/app.rb
@@ -7,12 +7,12 @@ module Bouncer
     def call(env)
       context = RequestContext.new(CanonicalizedRequest.new(env))
 
-      outcome = if context.request.path == "/healthcheck"
+      outcome = if !context.valid?
+                  Outcome::BadRequest
+                elsif context.request.path == "/healthcheck"
                   Outcome::Healthcheck
                 elsif context.host.nil?
                   Outcome::UnrecognisedHost
-                elsif !context.valid?
-                  Outcome::BadRequest
                 elsif ["/404", "/410"].include?(context.request.path)
                   Outcome::TestThe4xxPages
                 elsif context.host.hostname == "www.direct.gov.uk" && context.request.path == "/__canary__"


### PR DESCRIPTION
In #283, we added code to capture `Addressable::URI::InvalidURIError`
exceptions and return 400 Bad Request responses. This was in order
to prevent logging this unactionable error in Sentry:
https://sentry.io/organizations/govuk/issues/2086648123/?project=202210&referrer=slack

The fix didn't work, because we capture the exception too late in
the logic, after `context.request.path` and `context.host.nil?`
have been called in `Bouncer::App.call`. By this point, the
exception has been raised already, before we have had a chance to
call `context.valid?`, so the Sentry errors have still been
happening.

We now check `context.valid?` as the very first thing before
digging into its internals.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
