### PR TITLE
Rewrite readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,51 @@
 
 This is a Rack-based redirector. It serves 301s and 410s from mappings created by [Transition](https://github.com/alphagov/transition).
 
-## Testing in a browser in development
+## Technical documentation
 
-These instructions assume you use the Dev VM, that Bouncer is running,
-and that you have some data in your Transition/Bouncer database.
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-Let's say you want to test `bis.gov.uk`.
+**Use GOV.UK Docker to run any commands that follow.**
 
-Get the IP address of your VM:
+### Running the tests
 
-    mac$ ping transition.dev.gov.uk
+```
+bundle exec rake
+```
 
-Then, add to hosts file on your Mac:
+### Testing redirects
 
-    mac$ cat /etc/hosts
-    10.1.1.254 dev.bis.gov.uk
+In order to test the redirect feature of this app, you can use a special `bouncer-redirect.dev.gov.uk` domain. We will create a mapping from this fake domain to GOV.UK.
 
-Then on your VM, as root, add this file:
+1. **Setup [the Transition repo](https://github.com/alphagov/transition).**
 
-    dev$ cat /etc/nginx/sites-available/bis.gov.uk
-    server {
-      server_name dev.bis.gov.uk;
-      listen 80;
+2. **Run the following command in the Transition repo.**
 
-      location / {
-        proxy_pass http://bouncer.dev.gov.uk-proxy;
-        proxy_set_header Host bis.gov.uk;
-      }
-    }
+  ```
+  bundle exec rake import:all:orgs_sites_hosts
+  ```
 
-Then link the file:
+  One of the created organisations will be "cabinet-office", which we will use in the next step.
 
-    dev$ sudo ln -s /etc/nginx/sites-available/bis.gov.uk /etc/nginx/sites-enabled/bis.gov.uk
+3. **Create a temporary site file in the Transition repo.**
 
-And restart nginx:
+  ```
+  site: bouncer-redirect
+  whitehall_slug: cabinet-office
+  homepage: https://www.gov.uk
+  tna_timestamp: 20141104112824
+  host: bouncer-redirect.dev.gov.uk
+  global: =301 https://www.gov.uk
+  ```
 
-    dev$ sudo service nginx restart
+4. **Run the following command in the Transition repo.**
 
-Now browse to http://dev.bis.gov.uk/410 and bask in the glory.
+  ```
+  bundle exec rake 'import:org_sites_hosts[<path-to-file>]'
+  ```
+
+  This will create the site in the shared Transition / Bouncer DB.
+
+5. **Start the Bouncer app and go to bouncer-redirect.dev.gov.uk.**
+
+  You should see that it redirects to GOV.UK, as specified in the site file.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ In order to test the redirect feature of this app, you can use a special `bounce
 5. **Start the Bouncer app and go to bouncer-redirect.dev.gov.uk.**
 
   You should see that it redirects to GOV.UK, as specified in the site file.
+
+## Licence
+
+[MIT License](LICENCE)

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec mr-sparkle --force-polling -- -p 3049


### PR DESCRIPTION
Rewrite README to favour GOV.UK Docker

https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

Depends on: https://github.com/alphagov/govuk-docker/pull/479

This was tricky because this repo shares a database with Transition,
and the features the app provides are quite advanced.

I don't know much about this repo myself. Since the aim of this PR is
to fix old references to the Dev VM, I'm going to defer:

- Extending the introduction with a comprehensive description of the
features of this repo and how it interacts with others.

- Adding a nomenclature section to explain terms like "site" and "alias".
