### PR TITLE
Revert "Explitly ignore UndefinedTable and StatementInvalid exceptions"

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,11 +1,3 @@
 require "govuk_app_config"
 GovukUnicorn.configure(self)
-
-GovukError.configure do |config|
-  config.data_sync_excluded_exceptions += [
-    "PG::UndefinedTable",
-    "ActiveRecord::StatementInvalid",
-  ]
-end
-
 working_directory File.dirname(File.dirname(__FILE__))


### PR DESCRIPTION
Reverts alphagov/bouncer#303 as it did not fix the issue we were seeing in Sentry.