### PR TITLE
Use postgres 13 when running tests in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,10 @@
 library("govuk")
 
 node {
+  // Run against the Postgres 13 Docker instance on GOV.UK CI
+  // The database name is set to transition because Bouncer shares its database
+  // with transition
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/transition_test")
+
   govuk.buildProject()
 }

--- a/Rakefile
+++ b/Rakefile
@@ -14,10 +14,11 @@ namespace :db do
       uri = URI.parse(ENV["TEST_DATABASE_URL"])
       host = "-h #{uri.host}"
       user = "-U #{uri.user}"
+      port = "-p #{uri.port}"
     end
 
-    sh "dropdb #{host} #{user} --if-exists transition_test"
-    sh "createdb #{host} #{user} --encoding=UTF8 --template=template0 transition_test"
-    sh "cat db/structure.sql | psql #{host} #{user} -d transition_test"
+    sh "dropdb #{port} #{host} #{user} -w --if-exists transition_test"
+    sh "createdb #{port} #{host} #{user} -w --encoding=UTF8 --template=template0 transition_test"
+    sh "cat db/structure.sql | psql #{port} #{host} #{user} -w -d transition_test"
   end
 end


### PR DESCRIPTION
This changes the JenkinsFile to use postgres 13. Bouncer shares its 
database with transition so the database name is transition-test.

Postgres 13 is available at port `54313` on the CI server. By explicitly 
setting the `TEST_DATABASE_URL`, we're telling Rails to use that 
Postgres server.

Previously, Rails implicitly used the default Postgres port `5432` which 
is a Postgres 9.6 server.

We now need to specify the port number and require no password when reseting the database in the CI environment.

Trello ticket: https://trello.com/c/zVdVJqFM

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
