### PR TITLE
Fix build bug where no port is specified for database

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ namespace :db do
       uri = URI.parse(ENV["TEST_DATABASE_URL"])
       host = "-h #{uri.host}"
       user = "-U #{uri.user}"
-      port = "-p #{uri.port}"
+      port = "-p #{uri.port}" if uri.port
     end
 
     sh "dropdb #{port} #{host} #{user} -w --if-exists transition_test"


### PR DESCRIPTION
db:reset calls dropdb to do the drop/rebuild. If there's
no port specified in the database url you still get a
-p but with no parameter, causing the command to fail.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
