### PR TITLE
Add Support for Prometheus Exporting

### DIFF
--- a/boot.rb
+++ b/boot.rb
@@ -1,5 +1,7 @@
 require "bundler/setup"
 require "bootsnap"
+require_relative "config/prometheus"
+
 RACK_ENV = ENV.fetch("RACK_ENV", "development")
 Bootsnap.setup(
   cache_dir: ENV.fetch("BOOTSNAP_CACHE_DIR", "tmp/cache"),

--- a/config/prometheus.rb
+++ b/config/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
## What?
This aims to add Prometheus support to Bouncer for use with EKS. Other GOV.UK Ruby apps normally put this config in `config/initialize` because they use Rails. But Bouncer doesn't use Rails, so instead we're putting it in `/config` and ~~seeing if it loads-in~~ explicitly requiring it from `boot.rb`. ~~I'm going by the assumption that this should work because Unicorn is configured in a similar approach.~~

I don't expect this change by itself to do anything, unless the environment variable `GOVUK_PROMETHEUS_EXPORTER` is set to `true`. This envvar is currently set globally in our k8s app ConfigMap.