### PR TITLE
Add prometheus metrics to bouncer

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,13 @@ require './boot'
 require 'rack/static'
 require './lib/active_record/rack/connection_management'
 
+if GovukPrometheusExporter.should_configure
+	require "prometheus_exporter"
+	require "prometheus_exporter/middleware"
+
+	use PrometheusExporter::Middleware, instrument: :prepend
+end
+
 use Sentry::Rack::CaptureExceptions
 use Bouncer::Cacher
 


### PR DESCRIPTION
We need to do this [differently to Rails, Sinatra](https://github.com/alphagov/govuk_app_config/blob/main/lib/govuk_app_config/govuk_prometheus_exporter.rb) because we're using a plain Rack middleware stack.

We need to use the `prepend` option for instrumentation as the app crashes if we use the default `alias_method`. Some documentation on this is in the [prometheus_exporter README](https://github.com/discourse/prometheus_exporter#choosing-the-style-of-method-patching)

My previous effort worked in terms of extracting the metrics, but seemed to leak memory horribly. I think I'd just got it very wrong. The workload stats on integration for this change seem stable after a couple of hours, so I think this is good to go.

(App metrics are working)

## Stable CPU

![Screenshot 2023-03-30 at 12 38 48](https://user-images.githubusercontent.com/773037/228824867-21d5c22a-5d1d-485d-8cfe-798e148922bb.png)

## Stable memory consumption

![Screenshot 2023-03-30 at 12 38 37](https://user-images.githubusercontent.com/773037/228824873-54d9f26c-b32c-488f-a384-f55a7ac966fb.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
