### PR TITLE
Send National Archives redirects straight to https

### DIFF
--- a/lib/bouncer/request_context.rb
+++ b/lib/bouncer/request_context.rb
@@ -48,7 +48,7 @@ module Bouncer
 
     def default_archive_url
       tna_timestamp = site.tna_timestamp.try(:strftime, "%Y%m%d%H%M%S")
-      "http://webarchive.nationalarchives.gov.uk/#{tna_timestamp}/http://#{host.hostname}#{request.non_canonicalised_fullpath}"
+      "https://webarchive.nationalarchives.gov.uk/#{tna_timestamp}/http://#{host.hostname}#{request.non_canonicalised_fullpath}"
     end
   end
 end

--- a/spec/features/http_request_handling_spec.rb
+++ b/spec/features/http_request_handling_spec.rb
@@ -361,7 +361,7 @@ describe "HTTP request handling" do
       it { is_expected.to include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
       it { is_expected.to include '<div class="organisation ministry-of-truth">' }
       it { is_expected.to include 'Visit the new Ministry of Truth site at <a href="http://www.gov.uk/government/organisations/ministry-of-truth">www.gov.uk/mot</a>' }
-      it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/an-archived-page?non-canonical-param=1">This item has been archived</a>' }
+      it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/an-archived-page?non-canonical-param=1">This item has been archived</a>' }
     end
   end
 
@@ -383,7 +383,7 @@ describe "HTTP request handling" do
       it { is_expected.to include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
       it { is_expected.to include '<div class="organisation ministry-of-truth">' }
       it { is_expected.to include 'Visit the new Ministry of Truth site at <a href="http://www.gov.uk/government/organisations/ministry-of-truth">www.gov.uk/mot</a>' }
-      it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/an-archived-page">This item has been archived</a>' }
+      it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/an-archived-page">This item has been archived</a>' }
       it { is_expected.to include 'Visit <a href="http://www.truthiness.co.uk/">www.truthiness.co.uk</a> for more information on this topic.' }
     end
   end
@@ -404,7 +404,7 @@ describe "HTTP request handling" do
       site.mappings.create \
         path: "/an-archived-page",
         type: "archive",
-        archive_url: "http://webarchive.nationalarchives.gov.uk/20130101000000/http://www.minitrue.gov.uk/an-archived-page/the_actual_page.php"
+        archive_url: "https://webarchive.nationalarchives.gov.uk/20130101000000/http://www.minitrue.gov.uk/an-archived-page/the_actual_page.php"
       get "http://www.minitrue.gov.uk/an-archived-page"
     end
 
@@ -416,7 +416,7 @@ describe "HTTP request handling" do
       it { is_expected.to include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
       it { is_expected.to include '<div class="organisation ministry-of-truth">' }
       it { is_expected.to include 'Visit the new Ministry of Truth site at <a href="http://www.gov.uk/government/organisations/ministry-of-truth">www.gov.uk/mot</a>' }
-      it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20130101000000/http://www.minitrue.gov.uk/an-archived-page/the_actual_page.php">This item has been archived</a>' }
+      it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20130101000000/http://www.minitrue.gov.uk/an-archived-page/the_actual_page.php">This item has been archived</a>' }
     end
   end
 
@@ -457,7 +457,7 @@ describe "HTTP request handling" do
       it { is_expected.to include "<title>404 - Not Found</title>" }
       it { is_expected.to include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
       it { is_expected.to include '<div class="organisation ministry-of-truth">' }
-      it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/an-unrecognised-page">UK Government Web Archive</a>' }
+      it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/an-unrecognised-page">UK Government Web Archive</a>' }
     end
   end
 
@@ -484,7 +484,7 @@ describe "HTTP request handling" do
       it { is_expected.to include "<title>404 - Not Found</title>" }
       it { is_expected.to include '<a href="http://www.gov.uk/government/organisations/ministry-of-love"><span>Ministry of Love</span></a>' }
       it { is_expected.to include '<div class="organisation ministry-of-love">' }
-      it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20130724103251/http://www.miniluv.gov.uk/an-unrecognised-page">UK Government Web Archive</a>' }
+      it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20130724103251/http://www.miniluv.gov.uk/an-unrecognised-page">UK Government Web Archive</a>' }
     end
   end
 
@@ -661,7 +661,7 @@ describe "HTTP request handling" do
       it { is_expected.to include "<title>404 - Not Found</title>" }
       it { is_expected.to include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
       it { is_expected.to include '<div class="organisation ministry-of-truth">' }
-      it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/404">UK Government Web Archive</a>' }
+      it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/404">UK Government Web Archive</a>' }
     end
   end
 
@@ -692,7 +692,7 @@ describe "HTTP request handling" do
       it { is_expected.to include '<a href="http://www.gov.uk/government/organisations/ministry-of-truth"><span>Ministry of Truth</span></a>' }
       it { is_expected.to include '<div class="organisation ministry-of-truth">' }
       it { is_expected.to include 'Visit the new Ministry of Truth site at <a href="http://www.gov.uk/government/organisations/ministry-of-truth">www.gov.uk/mot</a>' }
-      it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/410">This item has been archived</a>' }
+      it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20121026065214/http://www.minitrue.gov.uk/410">This item has been archived</a>' }
     end
   end
 
@@ -996,7 +996,7 @@ describe "HTTP request handling" do
           it { is_expected.to include '<a href="https://www.gov.uk/government/organisations/department-of-health"><span>Department of Health</span></a>' }
           it { is_expected.to include '<div class="organisation department-of-health">' }
           it { is_expected.to include 'Visit the new Department of Health site at <a href="https://www.gov.uk/government/organisations/department-of-health">www.gov.uk/doh</a>' }
-          it { is_expected.to include '<a href="http://webarchive.nationalarchives.gov.uk/20121026065214/http://www.dh.gov.uk/a/b/dh_digitalassets/c">This item has been archived</a>' }
+          it { is_expected.to include '<a href="https://webarchive.nationalarchives.gov.uk/20121026065214/http://www.dh.gov.uk/a/b/dh_digitalassets/c">This item has been archived</a>' }
         end
       end
 


### PR DESCRIPTION
At present, when we redirect a URL to the National Archives, we use the http scheme.

The first thing the NA CDN does is _permanently_ redirect this to the same URL over TLS (some lines removed for brevity):

```
> curl -L -Is http://guidanceanddata.defra.gov.uk/

HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Fri, 03 Nov 2023 10:43:34 GMT
Content-Type: text/html
Location: http://webarchive.nationalarchives.gov.uk/20150423095755/http://guidanceanddata.defra.gov.uk/

HTTP/1.1 301 Moved Permanently
Server: CloudFront
Date: Fri, 03 Nov 2023 10:43:34 GMT
Content-Type: text/html
Location: https://webarchive.nationalarchives.gov.uk/20150423095755/http://guidanceanddata.defra.gov.uk/
X-Cache: Redirect from cloudfront
```

We can remove a redirect hop from each of these by updating the default NA URL.

(I suspect we might be able to remove another redirect after this, however this requires a bit more investigation).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
