### PR TITLE
Change use of abbreviation to primary hostname

### DIFF
--- a/lib/bouncer/outcome/global_type.rb
+++ b/lib/bouncer/outcome/global_type.rb
@@ -14,7 +14,7 @@ module Bouncer
         when "archive"
           [410, { "Content-Type" => "text/html" }, [renderer.render(context.attributes_for_render, 410)]]
         else
-          message = "Can't serve unexpected global_type: #{context.site.global_type} for #{context.site.abbr}"
+          message = "Can't serve unexpected global_type: #{context.site.global_type} for #{context.site.default_hostname}"
           [500, { "Content-Type" => "text/plain" }, [message]]
         end
       end

--- a/lib/site.rb
+++ b/lib/site.rb
@@ -6,4 +6,8 @@ class Site < ActiveRecord::Base
   belongs_to :organisation
   has_many :hosts
   has_many :mappings
+
+  def default_hostname
+    @default_hostname ||= hosts.where(canonical_host_id: nil).order(:id).first.hostname
+  end
 end


### PR DESCRIPTION
In https://github.com/alphagov/transition/pull/1473, we have removed the need for an abbreviation to be specified for a site.

Therefore updating this app to no longer use that field since it may not always be present.

[Trello card](https://trello.com/c/HaVI5NDq)
