### PR TITLE
Update db/structure.sql from Transition

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,40 +1,36 @@
---
--- PostgreSQL database dump
---
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
-SET search_path = public, pg_catalog;
+SET row_security = off;
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
--- Name: daily_hit_totals; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE daily_hit_totals (
-    id integer NOT NULL,
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: daily_hit_totals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.daily_hit_totals (
+    id bigint NOT NULL,
     host_id integer NOT NULL,
     http_status character varying(3) NOT NULL,
     count integer NOT NULL,
@@ -46,7 +42,7 @@ CREATE TABLE daily_hit_totals (
 -- Name: daily_hit_totals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE daily_hit_totals_id_seq
+CREATE SEQUENCE public.daily_hit_totals_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -58,15 +54,15 @@ CREATE SEQUENCE daily_hit_totals_id_seq
 -- Name: daily_hit_totals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE daily_hit_totals_id_seq OWNED BY daily_hit_totals.id;
+ALTER SEQUENCE public.daily_hit_totals_id_seq OWNED BY public.daily_hit_totals.id;
 
 
 --
--- Name: hits; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: hits; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE hits (
-    id integer NOT NULL,
+CREATE TABLE public.hits (
+    id bigint NOT NULL,
     host_id integer NOT NULL,
     path character varying(2048) NOT NULL,
     http_status character varying(3) NOT NULL,
@@ -80,7 +76,7 @@ CREATE TABLE hits (
 -- Name: hits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE hits_id_seq
+CREATE SEQUENCE public.hits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -92,65 +88,29 @@ CREATE SEQUENCE hits_id_seq
 -- Name: hits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE hits_id_seq OWNED BY hits.id;
+ALTER SEQUENCE public.hits_id_seq OWNED BY public.hits.id;
 
 
 --
--- Name: hits_staging; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: hits_staging; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE hits_staging (
-    hostname character varying(255) DEFAULT NULL::character varying,
-    path text DEFAULT NULL::character varying,
-    http_status character varying(3) DEFAULT NULL::character varying,
+CREATE TABLE public.hits_staging (
+    hostname text,
+    path text,
+    http_status character varying(3),
     count integer,
     hit_on date
 );
 
 
 --
--- Name: hosts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: host_paths; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE hosts (
-    id integer NOT NULL,
-    site_id integer NOT NULL,
-    hostname character varying(255) NOT NULL,
-    ttl integer,
-    cname character varying(255) DEFAULT NULL::character varying,
-    live_cname character varying(255) DEFAULT NULL::character varying,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    ip_address character varying(255) DEFAULT NULL::character varying,
-    canonical_host_id integer
-);
-
-
---
--- Name: hmrc_all_hits; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE MATERIALIZED VIEW hmrc_all_hits AS
- SELECT hits.path,
-    sum(hits.count) AS count,
-    hits.http_status,
-    min(hits.mapping_id) AS mapping_id,
-    min(hits.host_id) AS host_id
-   FROM (hits
-     JOIN hosts ON ((hits.host_id = hosts.id)))
-  WHERE (hosts.site_id = 56)
-  GROUP BY hits.path, hits.http_status
-  ORDER BY sum(hits.count) DESC
-  WITH NO DATA;
-
-
---
--- Name: host_paths; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE host_paths (
-    id integer NOT NULL,
-    path character varying(2048) DEFAULT NULL::character varying,
+CREATE TABLE public.host_paths (
+    id bigint NOT NULL,
+    path character varying(2048),
     host_id integer,
     mapping_id integer,
     canonical_path character varying(2048)
@@ -161,7 +121,7 @@ CREATE TABLE host_paths (
 -- Name: host_paths_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE host_paths_id_seq
+CREATE SEQUENCE public.host_paths_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -173,14 +133,32 @@ CREATE SEQUENCE host_paths_id_seq
 -- Name: host_paths_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE host_paths_id_seq OWNED BY host_paths.id;
+ALTER SEQUENCE public.host_paths_id_seq OWNED BY public.host_paths.id;
+
+
+--
+-- Name: hosts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.hosts (
+    id bigint NOT NULL,
+    site_id integer NOT NULL,
+    hostname text NOT NULL,
+    ttl integer,
+    cname character varying(255),
+    live_cname character varying(255),
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    ip_address character varying(255),
+    canonical_host_id integer
+);
 
 
 --
 -- Name: hosts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE hosts_id_seq
+CREATE SEQUENCE public.hosts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -192,19 +170,19 @@ CREATE SEQUENCE hosts_id_seq
 -- Name: hosts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE hosts_id_seq OWNED BY hosts.id;
+ALTER SEQUENCE public.hosts_id_seq OWNED BY public.hosts.id;
 
 
 --
--- Name: imported_hits_files; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: imported_hits_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE imported_hits_files (
-    id integer NOT NULL,
-    filename character varying(255) DEFAULT NULL::character varying,
-    content_hash character varying(255) DEFAULT NULL::character varying,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
+CREATE TABLE public.imported_hits_files (
+    id bigint NOT NULL,
+    filename character varying(255),
+    content_hash character varying(255),
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
@@ -212,7 +190,7 @@ CREATE TABLE imported_hits_files (
 -- Name: imported_hits_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE imported_hits_files_id_seq
+CREATE SEQUENCE public.imported_hits_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -224,15 +202,15 @@ CREATE SEQUENCE imported_hits_files_id_seq
 -- Name: imported_hits_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE imported_hits_files_id_seq OWNED BY imported_hits_files.id;
+ALTER SEQUENCE public.imported_hits_files_id_seq OWNED BY public.imported_hits_files.id;
 
 
 --
--- Name: mappings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: mappings; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE mappings (
-    id integer NOT NULL,
+CREATE TABLE public.mappings (
+    id bigint NOT NULL,
     site_id integer NOT NULL,
     path character varying(2048) NOT NULL,
     new_url text,
@@ -245,18 +223,18 @@ CREATE TABLE mappings (
 
 
 --
--- Name: mappings_batch_entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: mappings_batch_entries; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE mappings_batch_entries (
-    id integer NOT NULL,
-    path character varying(2048) DEFAULT NULL::character varying,
+CREATE TABLE public.mappings_batch_entries (
+    id bigint NOT NULL,
+    path character varying(2048),
     mappings_batch_id integer,
     mapping_id integer,
     processed boolean DEFAULT false,
-    klass character varying(255) DEFAULT NULL::character varying,
-    new_url text DEFAULT NULL::character varying,
-    type character varying(255) DEFAULT NULL::character varying,
+    klass character varying(255),
+    new_url text,
+    type character varying(255),
     archive_url text
 );
 
@@ -265,7 +243,7 @@ CREATE TABLE mappings_batch_entries (
 -- Name: mappings_batch_entries_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE mappings_batch_entries_id_seq
+CREATE SEQUENCE public.mappings_batch_entries_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -277,26 +255,26 @@ CREATE SEQUENCE mappings_batch_entries_id_seq
 -- Name: mappings_batch_entries_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE mappings_batch_entries_id_seq OWNED BY mappings_batch_entries.id;
+ALTER SEQUENCE public.mappings_batch_entries_id_seq OWNED BY public.mappings_batch_entries.id;
 
 
 --
--- Name: mappings_batches; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: mappings_batches; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE mappings_batches (
-    id integer NOT NULL,
-    tag_list character varying(255) DEFAULT NULL::character varying,
-    new_url character varying(2048) DEFAULT NULL::character varying,
+CREATE TABLE public.mappings_batches (
+    id bigint NOT NULL,
+    tag_list character varying(255),
+    new_url character varying(2048),
     update_existing boolean,
     user_id integer,
     site_id integer,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
     state character varying(255) DEFAULT 'unqueued'::character varying,
     seen_outcome boolean DEFAULT false,
-    type character varying(255) DEFAULT NULL::character varying,
-    klass character varying(255) DEFAULT NULL::character varying
+    type character varying(255),
+    klass character varying(255)
 );
 
 
@@ -304,7 +282,7 @@ CREATE TABLE mappings_batches (
 -- Name: mappings_batches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE mappings_batches_id_seq
+CREATE SEQUENCE public.mappings_batches_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -316,14 +294,14 @@ CREATE SEQUENCE mappings_batches_id_seq
 -- Name: mappings_batches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE mappings_batches_id_seq OWNED BY mappings_batches.id;
+ALTER SEQUENCE public.mappings_batches_id_seq OWNED BY public.mappings_batches.id;
 
 
 --
 -- Name: mappings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE mappings_id_seq
+CREATE SEQUENCE public.mappings_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -335,51 +313,15 @@ CREATE SEQUENCE mappings_id_seq
 -- Name: mappings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE mappings_id_seq OWNED BY mappings.id;
+ALTER SEQUENCE public.mappings_id_seq OWNED BY public.mappings.id;
 
 
 --
--- Name: mhra_all_hits; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace: 
+-- Name: organisational_relationships; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE MATERIALIZED VIEW mhra_all_hits AS
- SELECT hits.path,
-    sum(hits.count) AS count,
-    hits.http_status,
-    min(hits.mapping_id) AS mapping_id,
-    min(hits.host_id) AS host_id
-   FROM (hits
-     JOIN hosts ON ((hits.host_id = hosts.id)))
-  WHERE (hosts.site_id = 447)
-  GROUP BY hits.path, hits.http_status
-  ORDER BY sum(hits.count) DESC
-  WITH NO DATA;
-
-
---
--- Name: ofsted_all_hits; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE MATERIALIZED VIEW ofsted_all_hits AS
- SELECT hits.path,
-    sum(hits.count) AS count,
-    hits.http_status,
-    min(hits.mapping_id) AS mapping_id,
-    min(hits.host_id) AS host_id
-   FROM (hits
-     JOIN hosts ON ((hits.host_id = hosts.id)))
-  WHERE (hosts.site_id = 403)
-  GROUP BY hits.path, hits.http_status
-  ORDER BY sum(hits.count) DESC
-  WITH NO DATA;
-
-
---
--- Name: organisational_relationships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE organisational_relationships (
-    id integer NOT NULL,
+CREATE TABLE public.organisational_relationships (
+    id bigint NOT NULL,
     parent_organisation_id integer,
     child_organisation_id integer
 );
@@ -389,7 +331,7 @@ CREATE TABLE organisational_relationships (
 -- Name: organisational_relationships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE organisational_relationships_id_seq
+CREATE SEQUENCE public.organisational_relationships_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -401,25 +343,25 @@ CREATE SEQUENCE organisational_relationships_id_seq
 -- Name: organisational_relationships_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE organisational_relationships_id_seq OWNED BY organisational_relationships.id;
+ALTER SEQUENCE public.organisational_relationships_id_seq OWNED BY public.organisational_relationships.id;
 
 
 --
--- Name: organisations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organisations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE organisations (
-    id integer NOT NULL,
+CREATE TABLE public.organisations (
+    id bigint NOT NULL,
     title character varying(255) NOT NULL,
-    homepage character varying(255) DEFAULT NULL::character varying,
-    furl character varying(255) DEFAULT NULL::character varying,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    css character varying(255) DEFAULT NULL::character varying,
-    ga_profile_id character varying(16) DEFAULT NULL::character varying,
-    whitehall_slug character varying(255) DEFAULT NULL::character varying,
-    whitehall_type character varying(255) DEFAULT NULL::character varying,
-    abbreviation character varying(255) DEFAULT NULL::character varying,
+    homepage character varying(255),
+    furl character varying(255),
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    css character varying(255),
+    ga_profile_id character varying(16),
+    whitehall_slug character varying(255),
+    whitehall_type character varying(255),
+    abbreviation character varying(255),
     content_id character varying(255) NOT NULL
 );
 
@@ -428,7 +370,7 @@ CREATE TABLE organisations (
 -- Name: organisations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE organisations_id_seq
+CREATE SEQUENCE public.organisations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -440,38 +382,38 @@ CREATE SEQUENCE organisations_id_seq
 -- Name: organisations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE organisations_id_seq OWNED BY organisations.id;
+ALTER SEQUENCE public.organisations_id_seq OWNED BY public.organisations.id;
 
 
 --
--- Name: organisations_sites; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: organisations_sites; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE organisations_sites (
+CREATE TABLE public.organisations_sites (
     site_id integer NOT NULL,
     organisation_id integer NOT NULL
 );
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
-    version character varying(255) NOT NULL
+CREATE TABLE public.schema_migrations (
+    version character varying NOT NULL
 );
 
 
 --
--- Name: sessions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: sessions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sessions (
-    id integer NOT NULL,
+CREATE TABLE public.sessions (
+    id bigint NOT NULL,
     session_id character varying(255) NOT NULL,
     data text,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -479,7 +421,7 @@ CREATE TABLE sessions (
 -- Name: sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sessions_id_seq
+CREATE SEQUENCE public.sessions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -491,29 +433,29 @@ CREATE SEQUENCE sessions_id_seq
 -- Name: sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sessions_id_seq OWNED BY sessions.id;
+ALTER SEQUENCE public.sessions_id_seq OWNED BY public.sessions.id;
 
 
 --
--- Name: sites; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: sites; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sites (
-    id integer NOT NULL,
+CREATE TABLE public.sites (
+    id bigint NOT NULL,
     organisation_id integer NOT NULL,
-    abbr character varying(255) NOT NULL,
-    query_params character varying(255) DEFAULT NULL::character varying,
-    tna_timestamp timestamp with time zone NOT NULL,
-    homepage character varying(255) DEFAULT NULL::character varying,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
+    abbr character varying(255),
+    query_params character varying(255),
+    tna_timestamp timestamp without time zone NOT NULL,
+    homepage character varying(255),
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
     global_new_url text,
     launch_date date,
-    special_redirect_strategy character varying(255) DEFAULT NULL::character varying,
+    special_redirect_strategy character varying(255),
     global_redirect_append_path boolean DEFAULT false NOT NULL,
-    global_type character varying(255) DEFAULT NULL::character varying,
-    homepage_title character varying(255) DEFAULT NULL::character varying,
-    homepage_furl character varying(255) DEFAULT NULL::character varying,
+    global_type character varying(255),
+    homepage_title character varying(255),
+    homepage_furl character varying(255),
     precompute_all_hits_view boolean DEFAULT false NOT NULL
 );
 
@@ -522,7 +464,7 @@ CREATE TABLE sites (
 -- Name: sites_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sites_id_seq
+CREATE SEQUENCE public.sites_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -534,22 +476,22 @@ CREATE SEQUENCE sites_id_seq
 -- Name: sites_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sites_id_seq OWNED BY sites.id;
+ALTER SEQUENCE public.sites_id_seq OWNED BY public.sites.id;
 
 
 --
--- Name: taggings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: taggings; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE taggings (
-    id integer NOT NULL,
+CREATE TABLE public.taggings (
+    id bigint NOT NULL,
     tag_id integer,
     taggable_id integer,
-    taggable_type character varying(255) DEFAULT NULL::character varying,
+    taggable_type character varying(255),
     tagger_id integer,
-    tagger_type character varying(255) DEFAULT NULL::character varying,
-    context character varying(128) DEFAULT NULL::character varying,
-    created_at timestamp with time zone
+    tagger_type character varying(255),
+    context character varying(128),
+    created_at timestamp without time zone
 );
 
 
@@ -557,7 +499,7 @@ CREATE TABLE taggings (
 -- Name: taggings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE taggings_id_seq
+CREATE SEQUENCE public.taggings_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -569,16 +511,16 @@ CREATE SEQUENCE taggings_id_seq
 -- Name: taggings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE taggings_id_seq OWNED BY taggings.id;
+ALTER SEQUENCE public.taggings_id_seq OWNED BY public.taggings.id;
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tags; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tags (
-    id integer NOT NULL,
-    name character varying(255) DEFAULT NULL::character varying,
+CREATE TABLE public.tags (
+    id bigint NOT NULL,
+    name character varying(255),
     taggings_count integer DEFAULT 0
 );
 
@@ -587,7 +529,7 @@ CREATE TABLE tags (
 -- Name: tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tags_id_seq
+CREATE SEQUENCE public.tags_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -599,23 +541,23 @@ CREATE SEQUENCE tags_id_seq
 -- Name: tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
+ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
-    id integer NOT NULL,
-    name character varying(255) DEFAULT NULL::character varying,
-    email character varying(255) DEFAULT NULL::character varying,
-    uid character varying(255) DEFAULT NULL::character varying,
+CREATE TABLE public.users (
+    id bigint NOT NULL,
+    name character varying(255),
+    email character varying(255),
+    uid character varying(255),
     permissions text,
     remotely_signed_out boolean DEFAULT false,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    organisation_slug character varying(255) DEFAULT NULL::character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    organisation_slug character varying(255),
     is_robot boolean DEFAULT false,
     disabled boolean DEFAULT false,
     organisation_content_id character varying(255)
@@ -626,7 +568,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -638,23 +580,23 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: versions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE versions (
-    id integer NOT NULL,
+CREATE TABLE public.versions (
+    id bigint NOT NULL,
     item_type character varying(255) NOT NULL,
     item_id integer NOT NULL,
     event character varying(255) NOT NULL,
-    whodunnit character varying(255) DEFAULT NULL::character varying,
+    whodunnit character varying(255),
     user_id integer,
-    object_changes text,
-    object text,
-    created_at timestamp with time zone
+    created_at timestamp without time zone,
+    object jsonb,
+    object_changes jsonb
 );
 
 
@@ -662,7 +604,7 @@ CREATE TABLE versions (
 -- Name: versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE versions_id_seq
+CREATE SEQUENCE public.versions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -674,18 +616,18 @@ CREATE SEQUENCE versions_id_seq
 -- Name: versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE versions_id_seq OWNED BY versions.id;
+ALTER SEQUENCE public.versions_id_seq OWNED BY public.versions.id;
 
 
 --
--- Name: whitelisted_hosts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: whitelisted_hosts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE whitelisted_hosts (
-    id integer NOT NULL,
-    hostname character varying(255) NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+CREATE TABLE public.whitelisted_hosts (
+    id bigint NOT NULL,
+    hostname text NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -693,7 +635,7 @@ CREATE TABLE whitelisted_hosts (
 -- Name: whitelisted_hosts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE whitelisted_hosts_id_seq
+CREATE SEQUENCE public.whitelisted_hosts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -705,687 +647,616 @@ CREATE SEQUENCE whitelisted_hosts_id_seq
 -- Name: whitelisted_hosts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE whitelisted_hosts_id_seq OWNED BY whitelisted_hosts.id;
+ALTER SEQUENCE public.whitelisted_hosts_id_seq OWNED BY public.whitelisted_hosts.id;
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: daily_hit_totals id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY daily_hit_totals ALTER COLUMN id SET DEFAULT nextval('daily_hit_totals_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY hits ALTER COLUMN id SET DEFAULT nextval('hits_id_seq'::regclass);
+ALTER TABLE ONLY public.daily_hit_totals ALTER COLUMN id SET DEFAULT nextval('public.daily_hit_totals_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: hits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY host_paths ALTER COLUMN id SET DEFAULT nextval('host_paths_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY hosts ALTER COLUMN id SET DEFAULT nextval('hosts_id_seq'::regclass);
+ALTER TABLE ONLY public.hits ALTER COLUMN id SET DEFAULT nextval('public.hits_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: host_paths id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY imported_hits_files ALTER COLUMN id SET DEFAULT nextval('imported_hits_files_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY mappings ALTER COLUMN id SET DEFAULT nextval('mappings_id_seq'::regclass);
+ALTER TABLE ONLY public.host_paths ALTER COLUMN id SET DEFAULT nextval('public.host_paths_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: hosts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY mappings_batch_entries ALTER COLUMN id SET DEFAULT nextval('mappings_batch_entries_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY mappings_batches ALTER COLUMN id SET DEFAULT nextval('mappings_batches_id_seq'::regclass);
+ALTER TABLE ONLY public.hosts ALTER COLUMN id SET DEFAULT nextval('public.hosts_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: imported_hits_files id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY organisational_relationships ALTER COLUMN id SET DEFAULT nextval('organisational_relationships_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY organisations ALTER COLUMN id SET DEFAULT nextval('organisations_id_seq'::regclass);
+ALTER TABLE ONLY public.imported_hits_files ALTER COLUMN id SET DEFAULT nextval('public.imported_hits_files_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: mappings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sessions ALTER COLUMN id SET DEFAULT nextval('sessions_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY sites ALTER COLUMN id SET DEFAULT nextval('sites_id_seq'::regclass);
+ALTER TABLE ONLY public.mappings ALTER COLUMN id SET DEFAULT nextval('public.mappings_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: mappings_batch_entries id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY taggings ALTER COLUMN id SET DEFAULT nextval('taggings_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
+ALTER TABLE ONLY public.mappings_batch_entries ALTER COLUMN id SET DEFAULT nextval('public.mappings_batch_entries_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: mappings_batches id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq'::regclass);
+ALTER TABLE ONLY public.mappings_batches ALTER COLUMN id SET DEFAULT nextval('public.mappings_batches_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: organisational_relationships id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY whitelisted_hosts ALTER COLUMN id SET DEFAULT nextval('whitelisted_hosts_id_seq'::regclass);
+ALTER TABLE ONLY public.organisational_relationships ALTER COLUMN id SET DEFAULT nextval('public.organisational_relationships_id_seq'::regclass);
 
 
 --
--- Name: daily_hit_totals_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organisations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY daily_hit_totals
+ALTER TABLE ONLY public.organisations ALTER COLUMN id SET DEFAULT nextval('public.organisations_id_seq'::regclass);
+
+
+--
+-- Name: sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sessions ALTER COLUMN id SET DEFAULT nextval('public.sessions_id_seq'::regclass);
+
+
+--
+-- Name: sites id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sites ALTER COLUMN id SET DEFAULT nextval('public.sites_id_seq'::regclass);
+
+
+--
+-- Name: taggings id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.taggings ALTER COLUMN id SET DEFAULT nextval('public.taggings_id_seq'::regclass);
+
+
+--
+-- Name: tags id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.tags ALTER COLUMN id SET DEFAULT nextval('public.tags_id_seq'::regclass);
+
+
+--
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Name: versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions ALTER COLUMN id SET DEFAULT nextval('public.versions_id_seq'::regclass);
+
+
+--
+-- Name: whitelisted_hosts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.whitelisted_hosts ALTER COLUMN id SET DEFAULT nextval('public.whitelisted_hosts_id_seq'::regclass);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: daily_hit_totals daily_hit_totals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.daily_hit_totals
     ADD CONSTRAINT daily_hit_totals_pkey PRIMARY KEY (id);
 
 
 --
--- Name: hits_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: hits hits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY hits
+ALTER TABLE ONLY public.hits
     ADD CONSTRAINT hits_pkey PRIMARY KEY (id);
 
 
 --
--- Name: host_paths_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: host_paths host_paths_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY host_paths
+ALTER TABLE ONLY public.host_paths
     ADD CONSTRAINT host_paths_pkey PRIMARY KEY (id);
 
 
 --
--- Name: hosts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: hosts hosts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY hosts
+ALTER TABLE ONLY public.hosts
     ADD CONSTRAINT hosts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: imported_hits_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: imported_hits_files imported_hits_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY imported_hits_files
+ALTER TABLE ONLY public.imported_hits_files
     ADD CONSTRAINT imported_hits_files_pkey PRIMARY KEY (id);
 
 
 --
--- Name: mappings_batch_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: mappings_batch_entries mappings_batch_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY mappings_batch_entries
+ALTER TABLE ONLY public.mappings_batch_entries
     ADD CONSTRAINT mappings_batch_entries_pkey PRIMARY KEY (id);
 
 
 --
--- Name: mappings_batches_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: mappings_batches mappings_batches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY mappings_batches
+ALTER TABLE ONLY public.mappings_batches
     ADD CONSTRAINT mappings_batches_pkey PRIMARY KEY (id);
 
 
 --
--- Name: mappings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: mappings mappings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY mappings
+ALTER TABLE ONLY public.mappings
     ADD CONSTRAINT mappings_pkey PRIMARY KEY (id);
 
 
 --
--- Name: organisational_relationships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organisational_relationships organisational_relationships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY organisational_relationships
+ALTER TABLE ONLY public.organisational_relationships
     ADD CONSTRAINT organisational_relationships_pkey PRIMARY KEY (id);
 
 
 --
--- Name: organisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: organisations organisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY organisations
+ALTER TABLE ONLY public.organisations
     ADD CONSTRAINT organisations_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sessions
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: sessions sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sessions
     ADD CONSTRAINT sessions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: sites_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: sites sites_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sites
+ALTER TABLE ONLY public.sites
     ADD CONSTRAINT sites_pkey PRIMARY KEY (id);
 
 
 --
--- Name: taggings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: taggings taggings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY taggings
+ALTER TABLE ONLY public.taggings
     ADD CONSTRAINT taggings_pkey PRIMARY KEY (id);
 
 
 --
--- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tags
+ALTER TABLE ONLY public.tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: versions versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY versions
+ALTER TABLE ONLY public.versions
     ADD CONSTRAINT versions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: whitelisted_hosts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: whitelisted_hosts whitelisted_hosts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY whitelisted_hosts
+ALTER TABLE ONLY public.whitelisted_hosts
     ADD CONSTRAINT whitelisted_hosts_pkey PRIMARY KEY (id);
 
 
 --
--- Name: index_daily_hit_totals_on_host_id_and_total_on_and_http_status; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_daily_hit_totals_on_host_id_and_total_on_and_http_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_daily_hit_totals_on_host_id_and_total_on_and_http_status ON daily_hit_totals USING btree (host_id, total_on, http_status);
+CREATE UNIQUE INDEX index_daily_hit_totals_on_host_id_and_total_on_and_http_status ON public.daily_hit_totals USING btree (host_id, total_on, http_status);
 
 
 --
--- Name: index_hits_on_host_id_and_hit_on; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_hits_on_host_id_and_hit_on; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_hits_on_host_id_and_hit_on ON hits USING btree (host_id, hit_on);
+CREATE INDEX index_hits_on_host_id_and_hit_on ON public.hits USING btree (host_id, hit_on);
 
 
 --
--- Name: index_hits_on_host_id_and_http_status; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_hits_on_host_id_and_http_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_hits_on_host_id_and_http_status ON hits USING btree (host_id, http_status);
+CREATE INDEX index_hits_on_host_id_and_http_status ON public.hits USING btree (host_id, http_status);
 
 
 --
--- Name: index_hits_on_host_id_and_path_and_hit_on_and_http_status; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_hits_on_host_id_and_path_and_hit_on_and_http_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_hits_on_host_id_and_path_and_hit_on_and_http_status ON hits USING btree (host_id, path, hit_on, http_status);
+CREATE UNIQUE INDEX index_hits_on_host_id_and_path_and_hit_on_and_http_status ON public.hits USING btree (host_id, path, hit_on, http_status);
 
 
 --
--- Name: index_hits_on_mapping_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_hits_on_mapping_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_hits_on_mapping_id ON hits USING btree (mapping_id);
+CREATE INDEX index_hits_on_mapping_id ON public.hits USING btree (mapping_id);
 
 
 --
--- Name: index_host_paths_on_canonical_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_host_paths_on_canonical_path; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_host_paths_on_canonical_path ON host_paths USING btree (canonical_path);
+CREATE INDEX index_host_paths_on_canonical_path ON public.host_paths USING btree (canonical_path);
 
 
 --
--- Name: index_host_paths_on_host_id_and_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_host_paths_on_host_id_and_path; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_host_paths_on_host_id_and_path ON host_paths USING btree (host_id, path);
+CREATE UNIQUE INDEX index_host_paths_on_host_id_and_path ON public.host_paths USING btree (host_id, path);
 
 
 --
--- Name: index_host_paths_on_mapping_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_host_paths_on_mapping_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_host_paths_on_mapping_id ON host_paths USING btree (mapping_id);
+CREATE INDEX index_host_paths_on_mapping_id ON public.host_paths USING btree (mapping_id);
 
 
 --
--- Name: index_hosts_on_canonical_host_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_hosts_on_canonical_host_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_hosts_on_canonical_host_id ON hosts USING btree (canonical_host_id);
+CREATE INDEX index_hosts_on_canonical_host_id ON public.hosts USING btree (canonical_host_id);
 
 
 --
--- Name: index_hosts_on_host; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_hosts_on_host; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_hosts_on_host ON hosts USING btree (hostname);
+CREATE UNIQUE INDEX index_hosts_on_host ON public.hosts USING btree (hostname);
 
 
 --
--- Name: index_hosts_on_site_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_hosts_on_site_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_hosts_on_site_id ON hosts USING btree (site_id);
+CREATE INDEX index_hosts_on_site_id ON public.hosts USING btree (site_id);
 
 
 --
--- Name: index_imported_hits_files_on_filename; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_imported_hits_files_on_filename; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_imported_hits_files_on_filename ON imported_hits_files USING btree (filename);
+CREATE UNIQUE INDEX index_imported_hits_files_on_filename ON public.imported_hits_files USING btree (filename);
 
 
 --
--- Name: index_mappings_batch_entries_on_mappings_batch_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_mappings_batch_entries_on_mappings_batch_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_mappings_batch_entries_on_mappings_batch_id ON mappings_batch_entries USING btree (mappings_batch_id);
+CREATE INDEX index_mappings_batch_entries_on_mappings_batch_id ON public.mappings_batch_entries USING btree (mappings_batch_id);
 
 
 --
--- Name: index_mappings_batches_on_user_id_and_site_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_mappings_batches_on_user_id_and_site_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_mappings_batches_on_user_id_and_site_id ON mappings_batches USING btree (user_id, site_id);
+CREATE INDEX index_mappings_batches_on_user_id_and_site_id ON public.mappings_batches USING btree (user_id, site_id);
 
 
 --
--- Name: index_mappings_on_hit_count; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_mappings_on_hit_count; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_mappings_on_hit_count ON mappings USING btree (hit_count);
+CREATE INDEX index_mappings_on_hit_count ON public.mappings USING btree (hit_count);
 
 
 --
--- Name: index_mappings_on_site_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_mappings_on_site_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_mappings_on_site_id ON mappings USING btree (site_id);
+CREATE INDEX index_mappings_on_site_id ON public.mappings USING btree (site_id);
 
 
 --
--- Name: index_mappings_on_site_id_and_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_mappings_on_site_id_and_path; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_mappings_on_site_id_and_path ON mappings USING btree (site_id, path);
+CREATE UNIQUE INDEX index_mappings_on_site_id_and_path ON public.mappings USING btree (site_id, path);
 
 
 --
--- Name: index_mappings_on_site_id_and_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_mappings_on_site_id_and_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_mappings_on_site_id_and_type ON mappings USING btree (site_id, type);
+CREATE INDEX index_mappings_on_site_id_and_type ON public.mappings USING btree (site_id, type);
 
 
 --
--- Name: index_organisational_relationships_on_child_organisation_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organisational_relationships_on_child_organisation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organisational_relationships_on_child_organisation_id ON organisational_relationships USING btree (child_organisation_id);
+CREATE INDEX index_organisational_relationships_on_child_organisation_id ON public.organisational_relationships USING btree (child_organisation_id);
 
 
 --
--- Name: index_organisational_relationships_on_parent_organisation_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organisational_relationships_on_parent_organisation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organisational_relationships_on_parent_organisation_id ON organisational_relationships USING btree (parent_organisation_id);
+CREATE INDEX index_organisational_relationships_on_parent_organisation_id ON public.organisational_relationships USING btree (parent_organisation_id);
 
 
 --
--- Name: index_organisations_on_content_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organisations_on_content_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organisations_on_content_id ON organisations USING btree (content_id);
+CREATE UNIQUE INDEX index_organisations_on_content_id ON public.organisations USING btree (content_id);
 
 
 --
--- Name: index_organisations_on_title; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organisations_on_title; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organisations_on_title ON organisations USING btree (title);
+CREATE INDEX index_organisations_on_title ON public.organisations USING btree (title);
 
 
 --
--- Name: index_organisations_on_whitehall_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organisations_on_whitehall_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organisations_on_whitehall_slug ON organisations USING btree (whitehall_slug);
+CREATE UNIQUE INDEX index_organisations_on_whitehall_slug ON public.organisations USING btree (whitehall_slug);
 
 
 --
--- Name: index_organisations_sites_on_site_id_and_organisation_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_organisations_sites_on_site_id_and_organisation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organisations_sites_on_site_id_and_organisation_id ON organisations_sites USING btree (site_id, organisation_id);
+CREATE UNIQUE INDEX index_organisations_sites_on_site_id_and_organisation_id ON public.organisations_sites USING btree (site_id, organisation_id);
 
 
 --
--- Name: index_sessions_on_session_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_sessions_on_session_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_sessions_on_session_id ON sessions USING btree (session_id);
+CREATE INDEX index_sessions_on_session_id ON public.sessions USING btree (session_id);
 
 
 --
--- Name: index_sessions_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_sessions_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_sessions_on_updated_at ON sessions USING btree (updated_at);
+CREATE INDEX index_sessions_on_updated_at ON public.sessions USING btree (updated_at);
 
 
 --
--- Name: index_sites_on_organisation_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_sites_on_organisation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_sites_on_organisation_id ON sites USING btree (organisation_id);
+CREATE INDEX index_sites_on_organisation_id ON public.sites USING btree (organisation_id);
 
 
 --
--- Name: index_sites_on_site; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_sites_on_site; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_sites_on_site ON sites USING btree (abbr);
+CREATE UNIQUE INDEX index_sites_on_site ON public.sites USING btree (abbr);
 
 
 --
--- Name: index_taggings_on_taggable_id_and_taggable_type_and_context; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_taggings_on_taggable_id_and_taggable_type_and_context; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_taggings_on_taggable_id_and_taggable_type_and_context ON taggings USING btree (taggable_id, taggable_type, context);
+CREATE INDEX index_taggings_on_taggable_id_and_taggable_type_and_context ON public.taggings USING btree (taggable_id, taggable_type, context);
 
 
 --
--- Name: index_taggings_on_taggable_type_and_taggable_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_taggings_on_taggable_type_and_taggable_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_taggings_on_taggable_type_and_taggable_id ON taggings USING btree (taggable_type, taggable_id);
+CREATE INDEX index_taggings_on_taggable_type_and_taggable_id ON public.taggings USING btree (taggable_type, taggable_id);
 
 
 --
--- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_name ON tags USING btree (name);
+CREATE UNIQUE INDEX index_tags_on_name ON public.tags USING btree (name);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (item_type, item_id);
+CREATE INDEX index_versions_on_item_type_and_item_id ON public.versions USING btree (item_type, item_id);
 
 
 --
--- Name: index_whitelisted_hosts_on_hostname; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_whitelisted_hosts_on_hostname; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_whitelisted_hosts_on_hostname ON whitelisted_hosts USING btree (hostname);
+CREATE UNIQUE INDEX index_whitelisted_hosts_on_hostname ON public.whitelisted_hosts USING btree (hostname);
 
 
 --
--- Name: taggings_idx; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: taggings_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX taggings_idx ON taggings USING btree (tag_id, taggable_id, taggable_type, context, tagger_id, tagger_type);
-
-
---
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
+CREATE UNIQUE INDEX taggings_idx ON public.taggings USING btree (tag_id, taggable_id, taggable_type, context, tagger_id, tagger_type);
 
 
 --
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user",public;
+SET search_path TO "$user", public;
+
+INSERT INTO "schema_migrations" (version) VALUES
+('20231212143730'),
+('20231020093533'),
+('20231017095753'),
+('20221020085112'),
+('20161111172455'),
+('20160314150053'),
+('20160314150052'),
+('20150715141152'),
+('20150429154045'),
+('20150428155430'),
+('20150423102347'),
+('20150421161957'),
+('20150421161752'),
+('20150320164433'),
+('20141120164444'),
+('20141119113045'),
+('20141118121300'),
+('20141118112125'),
+('20141114110930'),
+('20141113115152'),
+('20141111093926'),
+('20141103142639'),
+('20141103111339'),
+('20141103110325'),
+('20141031104246'),
+('20140925104317'),
+('20140924105220'),
+('20140922152625'),
+('20140912150755'),
+('20140911113424'),
+('20140815095728'),
+('20140724164511'),
+('20140708144520'),
+('20140625132230'),
+('20140623135055'),
+('20140618145219'),
+('20140618092821'),
+('20140613165318'),
+('20140611144610'),
+('20140606155408'),
+('20140529164329'),
+('20140529130515'),
+('20140528161617'),
+('20140523100338'),
+('20140520154514'),
+('20140515135431'),
+('20140507103006'),
+('20140502160711'),
+('20140502114341'),
+('20140422184036'),
+('20140422160500'),
+('20140417100412'),
+('20140404112839'),
+('20140331121029'),
+('20140331115315'),
+('20140228174448'),
+('20140228173250'),
+('20140227154752'),
+('20140227154306'),
+('20140225175741'),
+('20140225161453'),
+('20140225152616'),
+('20140127151419'),
+('20140127151418'),
+('20131231133153'),
+('20131203115518'),
+('20131203102650'),
+('20131202174921'),
+('20131202093544'),
+('20131128155022'),
+('20131128150000'),
+('20131128120152'),
+('20131127164943'),
+('20131127140136'),
+('20131112133657'),
+('20131108121241'),
+('20131107202738'),
+('20131107192158'),
+('20131106102619'),
+('20131104141642'),
+('20131023082026'),
+('20131018160637'),
+('20131010140146'),
+('20131010115334'),
+('20130927131427'),
+('20130926082808'),
+('20130925162249'),
+('20130918110810'),
+('20130913124740'),
+('20130910135517'),
+('20130910133049');
 
-INSERT INTO schema_migrations (version) VALUES ('20130910133049');
-
-INSERT INTO schema_migrations (version) VALUES ('20130910135517');
-
-INSERT INTO schema_migrations (version) VALUES ('20130913124740');
-
-INSERT INTO schema_migrations (version) VALUES ('20130918110810');
-
-INSERT INTO schema_migrations (version) VALUES ('20130925162249');
-
-INSERT INTO schema_migrations (version) VALUES ('20130926082808');
-
-INSERT INTO schema_migrations (version) VALUES ('20130927131427');
-
-INSERT INTO schema_migrations (version) VALUES ('20131010115334');
-
-INSERT INTO schema_migrations (version) VALUES ('20131010140146');
-
-INSERT INTO schema_migrations (version) VALUES ('20131018160637');
-
-INSERT INTO schema_migrations (version) VALUES ('20131023082026');
-
-INSERT INTO schema_migrations (version) VALUES ('20131104141642');
-
-INSERT INTO schema_migrations (version) VALUES ('20131106102619');
-
-INSERT INTO schema_migrations (version) VALUES ('20131107192158');
-
-INSERT INTO schema_migrations (version) VALUES ('20131107202738');
-
-INSERT INTO schema_migrations (version) VALUES ('20131108121241');
-
-INSERT INTO schema_migrations (version) VALUES ('20131112133657');
-
-INSERT INTO schema_migrations (version) VALUES ('20131127140136');
-
-INSERT INTO schema_migrations (version) VALUES ('20131127164943');
-
-INSERT INTO schema_migrations (version) VALUES ('20131128120152');
-
-INSERT INTO schema_migrations (version) VALUES ('20131128150000');
-
-INSERT INTO schema_migrations (version) VALUES ('20131128155022');
-
-INSERT INTO schema_migrations (version) VALUES ('20131202093544');
-
-INSERT INTO schema_migrations (version) VALUES ('20131202174921');
-
-INSERT INTO schema_migrations (version) VALUES ('20131203102650');
-
-INSERT INTO schema_migrations (version) VALUES ('20131203115518');
-
-INSERT INTO schema_migrations (version) VALUES ('20131231133153');
-
-INSERT INTO schema_migrations (version) VALUES ('20140127151418');
-
-INSERT INTO schema_migrations (version) VALUES ('20140127151419');
-
-INSERT INTO schema_migrations (version) VALUES ('20140225152616');
-
-INSERT INTO schema_migrations (version) VALUES ('20140225161453');
-
-INSERT INTO schema_migrations (version) VALUES ('20140225175741');
-
-INSERT INTO schema_migrations (version) VALUES ('20140227154306');
-
-INSERT INTO schema_migrations (version) VALUES ('20140227154752');
-
-INSERT INTO schema_migrations (version) VALUES ('20140228173250');
-
-INSERT INTO schema_migrations (version) VALUES ('20140228174448');
-
-INSERT INTO schema_migrations (version) VALUES ('20140331115315');
-
-INSERT INTO schema_migrations (version) VALUES ('20140331121029');
-
-INSERT INTO schema_migrations (version) VALUES ('20140404112839');
-
-INSERT INTO schema_migrations (version) VALUES ('20140417100412');
-
-INSERT INTO schema_migrations (version) VALUES ('20140422160500');
-
-INSERT INTO schema_migrations (version) VALUES ('20140422184036');
-
-INSERT INTO schema_migrations (version) VALUES ('20140502114341');
-
-INSERT INTO schema_migrations (version) VALUES ('20140502160711');
-
-INSERT INTO schema_migrations (version) VALUES ('20140507103006');
-
-INSERT INTO schema_migrations (version) VALUES ('20140515135431');
-
-INSERT INTO schema_migrations (version) VALUES ('20140520154514');
-
-INSERT INTO schema_migrations (version) VALUES ('20140523100338');
-
-INSERT INTO schema_migrations (version) VALUES ('20140528161617');
-
-INSERT INTO schema_migrations (version) VALUES ('20140529130515');
-
-INSERT INTO schema_migrations (version) VALUES ('20140529164329');
-
-INSERT INTO schema_migrations (version) VALUES ('20140606155408');
-
-INSERT INTO schema_migrations (version) VALUES ('20140611144610');
-
-INSERT INTO schema_migrations (version) VALUES ('20140613165318');
-
-INSERT INTO schema_migrations (version) VALUES ('20140618092821');
-
-INSERT INTO schema_migrations (version) VALUES ('20140618145219');
-
-INSERT INTO schema_migrations (version) VALUES ('20140623135055');
-
-INSERT INTO schema_migrations (version) VALUES ('20140625132230');
-
-INSERT INTO schema_migrations (version) VALUES ('20140708144520');
-
-INSERT INTO schema_migrations (version) VALUES ('20140724164511');
-
-INSERT INTO schema_migrations (version) VALUES ('20140815095728');
-
-INSERT INTO schema_migrations (version) VALUES ('20140911113424');
-
-INSERT INTO schema_migrations (version) VALUES ('20140912150755');
-
-INSERT INTO schema_migrations (version) VALUES ('20140922152625');
-
-INSERT INTO schema_migrations (version) VALUES ('20140924105220');
-
-INSERT INTO schema_migrations (version) VALUES ('20140925104317');
-
-INSERT INTO schema_migrations (version) VALUES ('20141031104246');
-
-INSERT INTO schema_migrations (version) VALUES ('20141103110325');
-
-INSERT INTO schema_migrations (version) VALUES ('20141103111339');
-
-INSERT INTO schema_migrations (version) VALUES ('20141103142639');
-
-INSERT INTO schema_migrations (version) VALUES ('20141111093926');
-
-INSERT INTO schema_migrations (version) VALUES ('20141113115152');
-
-INSERT INTO schema_migrations (version) VALUES ('20141114110930');
-
-INSERT INTO schema_migrations (version) VALUES ('20141118112125');
-
-INSERT INTO schema_migrations (version) VALUES ('20141118121300');
-
-INSERT INTO schema_migrations (version) VALUES ('20141119113045');
-
-INSERT INTO schema_migrations (version) VALUES ('20141120164444');
-
-INSERT INTO schema_migrations (version) VALUES ('20150320164433');
-
-INSERT INTO schema_migrations (version) VALUES ('20150421161752');
-
-INSERT INTO schema_migrations (version) VALUES ('20150421161957');
-
-INSERT INTO schema_migrations (version) VALUES ('20150423102347');
-
-INSERT INTO schema_migrations (version) VALUES ('20150428155430');
-
-INSERT INTO schema_migrations (version) VALUES ('20150429154045');
-
-INSERT INTO schema_migrations (version) VALUES ('20150715141152');
-
-INSERT INTO schema_migrations (version) VALUES ('20160314150052');
-
-INSERT INTO schema_migrations (version) VALUES ('20160314150053');
-
-INSERT INTO schema_migrations (version) VALUES ('20161111172455');
 
 


### PR DESCRIPTION
Bouncer and Transition share a database, so we should keep the structure.sql here up to date when we modify the database schema in Transition. It looks like we haven't done since 2016
(https://github.com/alphagov/bouncer/pull/141).

Generated with `rails:schema:dump` in Transition and copied over.

[Trello card](https://trello.com/c/HaVI5NDq)
