### PR TITLE
Remove google analytics code from 404 / 410 pages

### DIFF
--- a/public/google-analytics.js
+++ b/public/google-analytics.js
@@ -1,7 +1,0 @@
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-26179049-8', 'auto');
-  ga('send', 'pageview');

--- a/templates/404.erb
+++ b/templates/404.erb
@@ -6,9 +6,6 @@
     <title>404 - Not Found</title>
     <link href="/gone.css" media="screen" rel="stylesheet" type="text/css">
     <!--[if lte IE 8]><link href="/ie.css" media="screen" rel="stylesheet" type="text/css"><![endif]-->
-    <% if ENV['RACK_ENV'] != 'development' %>
-      <script src="/google-analytics.js" type="text/javascript"></script>
-    <% end %>
   </head>
   <body>
     <div id="wrapper">

--- a/templates/410.erb
+++ b/templates/410.erb
@@ -6,9 +6,6 @@
     <title>410 - Page Archived</title>
     <link href="/gone.css" media="screen" rel="stylesheet" type="text/css">
     <!--[if lte IE 8]><link href="/ie.css" media="screen" rel="stylesheet" type="text/css"><![endif]-->
-    <% if ENV['RACK_ENV'] != 'development' %>
-      <script src="/google-analytics.js" type="text/javascript"></script>
-    <% end %>
   </head>
   <body>
     <div id="wrapper">


### PR DESCRIPTION
UA is going to be decommissioned imminently, so these aren't going to work shortly.

If we need page view information for bouncer, we can get it from the CDN logs.

Removing analytics rather than replacing it with GA4 means we don't have to solve a cookie consent problem.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
