### PR TITLE
Upgrade activerecord to 7.2.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org/"
 
-gem "activerecord", "7.2.1" # Ideally version should be synced with Transition
+gem "activerecord", "7.2.1.1" # Ideally version should be synced with Transition
 gem "bootsnap", require: false
 gem "erubis", "2.7.0"
 gem "govuk_app_config", "~> 9.14.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.2.1)
-      actionview (= 7.2.1)
-      activesupport (= 7.2.1)
+    actionpack (7.2.1.1)
+      actionview (= 7.2.1.1)
+      activesupport (= 7.2.1.1)
       nokogiri (>= 1.8.5)
       racc
       rack (>= 2.2.4, < 3.2)
@@ -12,19 +12,19 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actionview (7.2.1)
-      activesupport (= 7.2.1)
+    actionview (7.2.1.1)
+      activesupport (= 7.2.1.1)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activemodel (7.2.1)
-      activesupport (= 7.2.1)
-    activerecord (7.2.1)
-      activemodel (= 7.2.1)
-      activesupport (= 7.2.1)
+    activemodel (7.2.1.1)
+      activesupport (= 7.2.1.1)
+    activerecord (7.2.1.1)
+      activemodel (= 7.2.1.1)
+      activesupport (= 7.2.1.1)
       timeout (>= 0.4.0)
-    activesupport (7.2.1)
+    activesupport (7.2.1.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -351,9 +351,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.2.1)
-      actionpack (= 7.2.1)
-      activesupport (= 7.2.1)
+    railties (7.2.1.1)
+      actionpack (= 7.2.1.1)
+      activesupport (= 7.2.1.1)
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -454,7 +454,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  activerecord (= 7.2.1)
+  activerecord (= 7.2.1.1)
   bootsnap
   database_cleaner (= 2.0.2)
   erubis (= 2.7.0)


### PR DESCRIPTION
dependabot has opened a pull request on Transition to upgrade Rails to 7.2.1.1 but hasn't opened a pull request to upgrade activerecord on Bouncer. We aim to keep these in sync since they share a database, so I'm manually upgrading here

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
