### PR TITLE
PP-7685 Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
+    allow:
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,23 +26,6 @@ updates:
           - "rubocop"
           - "rubocop-*"
 
-  # Ruby needs to be upgraded manually in multiple places, so cannot
-  # be upgraded by Dependabot. That effectively makes the below
-  # config redundant, as ruby is the only updatable thing in the
-  # Dockerfile, although this may change in the future. We hope this
-  # config will save a dev from trying to upgrade ruby via Dependabot.
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-      day: tuesday
-      time: "07:00"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 25
-    ignore:
-      - dependency-name: ruby
-
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -51,4 +34,21 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
+
+  # Ruby needs to be upgraded manually in multiple places, so cannot
+  # be upgraded by Dependabot. That effectively makes the below
+  # config redundant, as ruby is the only updatable thing in the
+  # Dockerfile, although this may change in the future. We hope this
+  # config will save a dev from trying to upgrade ruby via Dependabot.
+  - package-ecosystem: docker
+    directory: /
+    ignore:
+      - dependency-name: ruby
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,19 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  # Ruby needs to be upgraded manually in multiple places, so cannot
+  # be upgraded by Dependabot. That effectively makes the below
+  # config redundant, as ruby is the only updatable thing in the
+  # Dockerfile, although this may change in the future. We hope this
+  # config will save a dev from trying to upgrade ruby via Dependabot.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: ruby
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily
 
@@ -12,6 +14,8 @@ updates:
   # config will save a dev from trying to upgrade ruby via Dependabot.
   - package-ecosystem: docker
     directory: /
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
     ignore:
@@ -19,5 +23,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     schedule:
       interval: daily
     groups:
@@ -30,6 +31,7 @@ updates:
     directory: /
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 25
     schedule:
       interval: weekly
     ignore:
@@ -39,5 +41,6 @@ updates:
     directory: /
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,20 @@ updates:
       default-days: 3
     schedule:
       interval: daily
+    groups:
+      test:
+        patterns:
+          - "benchmark"
+          - "database_cleaner"
+          - "pry"
+          - "rack-test"
+          - "rspec"
+          - "rspec-*"
+          - "simplecov"
+      lint:
+        patterns:
+          - "rubocop"
+          - "rubocop-*"
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,15 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     allow:
       - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25
-    schedule:
-      interval: daily
     groups:
       test:
         patterns:
@@ -31,18 +33,22 @@ updates:
   # config will save a dev from trying to upgrade ruby via Dependabot.
   - package-ecosystem: docker
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 25
-    schedule:
-      interval: weekly
     ignore:
       - dependency-name: ruby
 
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25
-    schedule:
-      interval: daily


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It adds Docker support (while ignoring Ruby, which must be upgraded manually), introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes. 

Security updates remain unaffected and continue to be raised immediately.